### PR TITLE
Fixed the 503 mint service unavailable bug

### DIFF
--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -153,7 +153,7 @@ async def get_wallet(mint_url: str, unit: str = "sat", load: bool = True) -> Wal
     id = f"{mint_url}_{unit}"
     if id not in _wallets:
         _wallets[id] = await Wallet.with_db(
-            mint_url, db=".wallet", load_all_keysets=True, unit=unit
+            mint_url, db=".wallet", unit=unit
         )
 
     if load:


### PR DESCRIPTION
This flag fetch all keysets from the db into the wallet, which is wrong given that we're initiating it for a mint. And load_mint sets the first keyset from all the keysets from the db, irrespective of the unit and the mint. 

Fixes #175