### PR TITLE
Add admin password warning

### DIFF
--- a/routstr/core/main.py
+++ b/routstr/core/main.py
@@ -63,7 +63,7 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
             s = await SettingsService.initialize(session)
 
         if not s.admin_password:
-            logger.info(
+            logger.warning(
                 f"Admin password is not set. Visit {s.http_url or 'http://localhost:8000'}/admin to set the password."
             )
 


### PR DESCRIPTION
Logs a warning if the admin password is not set, guiding the user to the admin page.