### PR TITLE
Fix not enough inputs to melt

### DIFF
--- a/routstr/payment/lnurl.py
+++ b/routstr/payment/lnurl.py
@@ -283,7 +283,7 @@ async def raw_send_to_lnurl(
             f"({min_sendable_sat} - {max_sendable_sat} {unit})"
         )
 
-    estimated_fees_sat = int(max(math.ceil((amount_msat / 1000) * 0.01), 2))
+    estimated_fees_sat = int(max(math.ceil((amount_msat / 1000) * 0.01), 2)) + 1
     estimated_fees_msat = estimated_fees_sat * 1000
     final_amount = amount_msat - estimated_fees_msat
 

--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -81,7 +81,7 @@ async def swap_to_primary_mint(
         amount_msat = token_amount
     else:
         raise ValueError("Invalid unit")
-    estimated_fee_sat = math.ceil(max(amount_msat // 1000 * 0.01, 2))
+    estimated_fee_sat = math.ceil(max(amount_msat // 1000 * 0.01, 2)) + 1
     amount_msat_after_fee = amount_msat - estimated_fee_sat * 1000
     primary_wallet = await get_wallet(settings.primary_mint, settings.primary_mint_unit)
 


### PR DESCRIPTION
this "Invalid or expired Cashu key: could not pay invoice: Mint Error: not enough inputs provided for melt. Provided: 256, needed: 257 (Code: 11000)"

comes up when using a small cashu token from an untrusted mint due to a rouding error