### PR TITLE
models system refactor

### DIFF
--- a/routstr/upstream/anthropic.py
+++ b/routstr/upstream/anthropic.py
@@ -61,6 +61,34 @@ class AnthropicUpstreamProvider(BaseUpstreamProvider):
             model_id = fixed_transforms[model_id]
         return model_id
 
+    def transform_parameters(self, data: dict) -> dict:
+        """Transform parameters for Anthropic API compatibility."""
+        if "reasoning" in data:
+            reasoning = data.pop("reasoning")
+            if isinstance(reasoning, dict) and "effort" in reasoning:
+                effort = reasoning.pop("effort")
+                if effort == "low":
+                    data["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": 8192,
+                    }
+                elif effort == "medium":
+                    data["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": 16384,
+                    }
+                elif effort == "high":
+                    data["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": 32768,
+                    }
+                elif effort == "none":
+                    data["thinking"] = {
+                        "type": "disabled",
+                    }
+
+        return super().transform_parameters(data)
+
     async def fetch_models(self) -> list[Model]:
         """Fetch Anthropic models from OpenRouter API filtered by anthropic source."""
         models_data = await async_fetch_openrouter_models(source_filter="anthropic")

--- a/routstr/upstream/openai.py
+++ b/routstr/upstream/openai.py
@@ -38,6 +38,12 @@ class OpenAIUpstreamProvider(BaseUpstreamProvider):
             "platform_url": cls.platform_url,
         }
 
+    def transform_parameters(self, data: dict) -> dict:
+        """Transform parameters for OpenAI API compatibility."""
+        if "max_tokens" in data:
+            data["max_completion_tokens"] = data.pop("max_tokens")
+        return super().transform_parameters(data)
+
     def transform_model_name(self, model_id: str) -> str:
         """Strip 'openai/' prefix for OpenAI API compatibility."""
         return model_id.removeprefix("openai/")


### PR DESCRIPTION
still work in progess

todo
instead of converting "input" to "messages" (in base.py@transform_parameters) 
it actually should redirect the call into the /v1/responses handler
