### PR TITLE
fix: unable to add multiple custom models

### DIFF
--- a/ui/app/providers/page.tsx
+++ b/ui/app/providers/page.tsx
@@ -389,7 +389,9 @@ export default function ProvidersPage() {
     useState<UpstreamProvider | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-  const [expandedProviders, setExpandedProviders] = useState<Set<number>>(new Set());
+  const [expandedProviders, setExpandedProviders] = useState<Set<number>>(
+    new Set()
+  );
   const [viewingModels, setViewingModels] = useState<number | null>(null);
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
   const [modelDialogState, setModelDialogState] = useState<{


### PR DESCRIPTION
fix not being able to add multiple custom models when provider does not have Provided Models