### PR TITLE
Fix Cashu insufficient-balance responses being wrapped as 401

### DIFF
--- a/routstr/auth.py
+++ b/routstr/auth.py
@@ -348,6 +348,8 @@ async def validate_bearer_key(
             )
 
             return new_key
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(
                 "Cashu token redemption failed",
@@ -997,18 +999,8 @@ async def adjust_payment_for_tokens(
                     }
                 },
             )
-    # Fallback: should not reach here, but release reservation just in case
-    logger.error(
-        "Unexpected fallback in adjust_payment_for_tokens - releasing reservation",
-        extra={"key_hash": key.hashed_key[:8] + "...", "model": model},
-    )
-    await release_reservation_only()
-    return {
-        "base_msats": deducted_max_cost,
-        "input_msats": 0,
-        "output_msats": 0,
-        "total_msats": deducted_max_cost,
-    }
+    # All calculate_cost variants are handled above.
+    raise AssertionError("Unreachable: unhandled calculate_cost result")
 
 
 async def periodic_key_reset() -> None:


### PR DESCRIPTION
## Summary
- Preserve original `HTTPException` in Cashu bearer key validation by re-raising `HTTPException` before the generic exception handler.
- Fixes the reported behavior where a real insufficient balance error (`402`) was being wrapped into `401 invalid_api_key`.
- Keeps unexpected Cashu parsing/redemption failures mapped to `401`, while allowing billing/quota errors to return their intended status codes.

## Reported Error
When `min_cost > 0` and balance is insufficient, the code raises:
- `402 insufficient_balance`

But due to broad exception handling, the final API response became:
- outer `401 invalid_api_key`
- inner message string containing `402: {'error': {...insufficient_balance...}}`

This PR prevents that wrapping so clients receive the correct `402` directly.

## Changes
- Updated `routstr/auth.py` in `validate_bearer_key` (Cashu path):
  - Added `except HTTPException: raise`
  - Kept `except Exception as e` for true unexpected failures
- Replaced unreachable fallback in `adjust_payment_for_tokens` with explicit assertion to satisfy static type checking.