### PR TITLE
fix: refund users when model returns zero tokens with non-zero cost

### DIFF
--- a/routstr/payment/cost_calculation.py
+++ b/routstr/payment/cost_calculation.py
@@ -180,7 +180,17 @@ async def calculate_cost(  # todo: can be sync
                     input_msats = int(cost_in_msats * input_ratio)
                     output_msats = cost_in_msats - input_msats
                 else:
-                    output_msats = cost_in_msats
+                    # No tokens reported — model produced empty output, issue full refund
+                    logger.warning(
+                        "Zero tokens with non-zero USD cost — issuing full refund",
+                        extra={
+                            "usd_cost": usd_cost,
+                            "model": response_data.get("model", "unknown"),
+                        },
+                    )
+                    input_msats = 0
+                    output_msats = 0
+                    cost_in_msats = 0
 
             logger.info(
                 "Using cost from usage data/details",


### PR DESCRIPTION
## Problem

When a model produces empty output (zero tokens reported) but the cost calculation returns a non-zero USD cost, the previous behavior was to charge the full amount as `output_msats`. This means users were being billed for responses where the model produced nothing.

## Fix

In the `else` branch of `calculate_cost()` (when no tokens are reported):
- **Before:** `output_msats = cost_in_msats` (user gets charged the full amount)
- **After:** Set `input_msats = 0`, `output_msats = 0`, `cost_in_msats = 0` — issuing a **full refund** to the user
- Added a `logger.warning` with `usd_cost` and `model` details for debugging/monitoring

## File Changed

- `routstr/payment/cost_calculation.py`

## Testing

The change is a simple conditional branch update. When `usage.input_tokens` and `usage.output_tokens` are both 0 but `usd_cost > 0`, the user now receives a full refund instead of being charged.