### PR TITLE
fix(deps): pin secp256k1 to commit (upstream branch deleted)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,4 +87,4 @@ disallow_untyped_decorators = true
 
 [tool.uv.sources]
 routstr = { workspace = true }
-secp256k1 = { git = "https://github.com/saschanaz/secp256k1-py", branch = "upgrade060" }
+secp256k1 = { git = "https://github.com/saschanaz/secp256k1-py", rev = "7d70a8ec7ca2db050d292c3759e49e75e21ac533" }

--- a/uv.lock
+++ b/uv.lock
@@ -2435,7 +2435,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.98.0" },
     { name = "pillow", specifier = ">=10" },
     { name = "python-json-logger", specifier = ">=2.0.0" },
-    { name = "secp256k1", git = "https://github.com/saschanaz/secp256k1-py?branch=upgrade060" },
+    { name = "secp256k1", git = "https://github.com/saschanaz/secp256k1-py?rev=7d70a8ec7ca2db050d292c3759e49e75e21ac533" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
     { name = "websockets", specifier = ">=12.0" },
 ]
@@ -2591,7 +2591,7 @@ wheels = [
 [[package]]
 name = "secp256k1"
 version = "0.14.0"
-source = { git = "https://github.com/saschanaz/secp256k1-py?branch=upgrade060#7d70a8ec7ca2db050d292c3759e49e75e21ac533" }
+source = { git = "https://github.com/saschanaz/secp256k1-py?rev=7d70a8ec7ca2db050d292c3759e49e75e21ac533#7d70a8ec7ca2db050d292c3759e49e75e21ac533" }
 dependencies = [
     { name = "cffi" },
 ]


### PR DESCRIPTION
# fix(deps): pin secp256k1 to commit (upstream branch deleted)

## Summary

`make dev-setup` (and any fresh `uv pip install -e .`) currently fails on `main` because `pyproject.toml` references a git branch on a third-party fork that no longer exists:

```
× Failed to download and build `secp256k1 @ git+https://github.com/saschanaz/secp256k1-py@upgrade060`
  ╰─▶ fatal: couldn't find remote ref refs/heads/upgrade060
```

This PR pins `secp256k1` to the exact commit already used by `uv.lock`, so no resolved dependency state changes — only the source pointer becomes durable.

## Root cause

`pyproject.toml` pinned the `secp256k1` dependency to a branch on a personal fork:

```toml
secp256k1 = { git = "https://github.com/saschanaz/secp256k1-py", branch = "upgrade060" }
```

That branch has since been deleted upstream. `git ls-remote https://github.com/saschanaz/secp256k1-py` confirms only `master`, `master2`, and `pyproject` remain.

`uv sync --dev` happens to work because `uv.lock` already pins the resolved commit (`7d70a8e…`). But `uv pip install -e .` re-resolves from `pyproject.toml` and fails — which is the second step of the `dev-setup` Makefile target, so the documented onboarding flow is broken for any new contributor.

## Fix

Pin to the commit instead of the branch — the same commit `uv.lock` already builds, so no behavioral change:

```toml
secp256k1 = { git = "https://github.com/saschanaz/secp256k1-py", rev = "7d70a8ec7ca2db050d292c3759e49e75e21ac533" }
```

`uv.lock` regenerated to match (source URL no longer has `?branch=upgrade060`).

## Reproduction

Before this PR, on a clean clone:

```bash
make dev-setup
# → fails on `uv pip install -e .` with "couldn't find remote ref refs/heads/upgrade060"
```

After this PR:

```bash
rm -rf .venv
make dev-setup
# → succeeds
```

## Test plan

- [x] `make dev-setup` succeeds on a fresh `.venv`
- [x] `make lint`
- [x] `make type-check`
- [x] `make test`

## Notes for reviewers

- Scope is intentionally minimal: only `pyproject.toml` and `uv.lock`.
- Longer-term, it may be worth replacing the personal-fork dependency with an upstream release once `secp256k1-py` ships `0.6.0`, but that's out of scope for this fix.
- The `uv pip install -e .` step in `make dev-setup` is also arguably redundant with `uv sync --dev` (which already installs `routstr` editable). Not changed here to keep this PR focused on the breakage.
