### PR TITLE
collapse when focus change

### DIFF
--- a/ui/app/providers/page.tsx
+++ b/ui/app/providers/page.tsx
@@ -297,16 +297,13 @@ export default function ProvidersPage() {
   };
 
   const toggleProviderExpansion = (providerId: number) => {
-    const newExpanded = new Set(expandedProviders);
-    if (newExpanded.has(providerId)) {
-      newExpanded.delete(providerId);
-    } else {
-      newExpanded.add(providerId);
-    }
-    setExpandedProviders(newExpanded);
-    if (!newExpanded.has(providerId)) {
+    if (expandedProviders.has(providerId)) {
+      setExpandedProviders(new Set());
       setViewingModels(null);
     } else {
+      // Accordion: only one provider open at a time so switching to another
+      // provider's models auto-collapses the previously expanded one.
+      setExpandedProviders(new Set([providerId]));
       setViewingModels(providerId);
     }
   };


### PR DESCRIPTION
## Problem

On the Providers page, expanding one provider's model list and then opening another provider's models did not collapse the first one. Because expansion state and the "which models to fetch" state could hold different providers at once, the previously opened panel went blank, and re-viewing it required two clicks (collapse, then expand again).

## Fix

Make provider model panels behave as an accordion: only one provider is expanded at a time. Opening a provider now auto-collapses any other open provider, so switching between providers' model lists works with a single click.
