### PR TITLE
fix(payment): refund truly-empty upstream responses billed a non-zero USD cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,3 @@ proof_backups
 
 *.todo
 ui_out
-
-# local cashu wallet state (never commit)
-.wallet/
-*.sqlite3-shm
-*.sqlite3-wal

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ proof_backups
 
 *.todo
 ui_out
+
+# local cashu wallet state (never commit)
+.wallet/
+*.sqlite3-shm
+*.sqlite3-wal

--- a/routstr/payment/cost_calculation.py
+++ b/routstr/payment/cost_calculation.py
@@ -109,6 +109,39 @@ async def calculate_cost(
     # Try USD cost first
     usd_cost = _resolve_usd_cost(usage_data, response_data)
     if usd_cost > 0:
+        truly_empty = (
+            input_tokens == 0
+            and output_tokens == 0
+            and cache_read_tokens == 0
+            and cache_creation_tokens == 0
+        )
+        if truly_empty:
+            logger.warning(
+                "Upstream reported a USD cost but the response carries no "
+                "tokens at all (input, output, cache-read and cache-creation "
+                "are all zero) — refunding in full rather than billing the "
+                "USD-derived cost for an empty response.",
+                extra={
+                    "model": response_data.get("model", "unknown"),
+                    "usd_cost": usd_cost,
+                    "usage_keys": sorted(usage_data.keys())
+                    if isinstance(usage_data, dict)
+                    else None,
+                },
+            )
+            return CostData(
+                base_msats=0,
+                input_msats=0,
+                output_msats=0,
+                total_msats=0,
+                total_usd=0.0,
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+                cache_read_msats=0,
+                cache_creation_msats=0,
+            )
         if input_tokens == 0 and output_tokens == 0:
             logger.warning(
                 "Upstream reported a USD cost but no token counts — "

--- a/routstr/payment/cost_calculation.py
+++ b/routstr/payment/cost_calculation.py
@@ -41,6 +41,28 @@ class CostDataError(BaseModel):
     code: str
 
 
+def _empty_cost(cls: type[CostData] = CostData) -> CostData:
+    """Build an all-zero cost object — a full refund for an empty response.
+
+    Shared by the two paths that must not bill: an upstream response with no
+    usage data at all, and one that reports a USD cost but carries zero tokens
+    in every bucket.
+    """
+    return cls(
+        base_msats=0,
+        input_msats=0,
+        output_msats=0,
+        total_msats=0,
+        total_usd=0.0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_msats=0,
+        cache_creation_msats=0,
+    )
+
+
 async def calculate_cost(
     response_data: dict,
     max_cost: int,
@@ -83,19 +105,7 @@ async def calculate_cost(
                 else None,
             },
         )
-        return MaxCostData(
-            base_msats=0,
-            input_msats=0,
-            output_msats=0,
-            total_msats=0,
-            total_usd=0.0,
-            input_tokens=0,
-            output_tokens=0,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_read_msats=0,
-            cache_creation_msats=0,
-        )
+        return _empty_cost(MaxCostData)
 
     usage_data = response_data.get("usage") or {}
     if not isinstance(usage_data, dict):
@@ -129,19 +139,7 @@ async def calculate_cost(
                     else None,
                 },
             )
-            return CostData(
-                base_msats=0,
-                input_msats=0,
-                output_msats=0,
-                total_msats=0,
-                total_usd=0.0,
-                input_tokens=0,
-                output_tokens=0,
-                cache_read_input_tokens=0,
-                cache_creation_input_tokens=0,
-                cache_read_msats=0,
-                cache_creation_msats=0,
-            )
+            return _empty_cost()
         if input_tokens == 0 and output_tokens == 0:
             logger.warning(
                 "Upstream reported a USD cost but no token counts — "

--- a/tests/unit/test_cost_calculation_caching.py
+++ b/tests/unit/test_cost_calculation_caching.py
@@ -405,6 +405,67 @@ async def test_deepseek_malformed_hit_tokens_coerce_to_zero() -> None:
 
 
 # ============================================================================
+# Truly-empty response with a non-zero USD cost → full refund
+#
+# When an upstream reports a USD cost but the response carries NO tokens at all
+# (input, output, cache-read and cache-creation all zero), billing the
+# USD-derived cost charges the user for nothing. Refund in full. The gate is
+# tightened relative to PR #489: a cache-read/-creation-only turn legitimately
+# reports zero prompt/completion tokens with a real cost and must still bill.
+# ============================================================================
+@pytest.mark.asyncio
+async def test_truly_empty_usd_cost_response_is_refunded(
+    mock_fixed_pricing: None,
+) -> None:
+    """0 input + 0 output + 0 cache tokens with a non-zero USD cost → refund."""
+    response = {
+        "model": "gpt-4",
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_cost": 0.01,  # non-zero USD cost despite no tokens
+        },
+    }
+    result = await calculate_cost(response, max_cost=100000)
+
+    assert isinstance(result, CostData)
+    assert result.total_msats == 0  # full refund
+    assert result.input_msats == 0
+    assert result.output_msats == 0
+    assert result.total_usd == 0.0
+    assert result.input_tokens == 0
+    assert result.output_tokens == 0
+    assert result.cache_read_input_tokens == 0
+    assert result.cache_creation_input_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_cache_read_only_usd_cost_response_is_billed(
+    mock_fixed_pricing: None,
+) -> None:
+    """Cache-read-only turn (0 prompt/completion, non-zero cost) still bills."""
+    response = {
+        "model": "claude-3-5-sonnet",
+        "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 1000,  # real cached usage
+            "cache_creation_input_tokens": 0,
+            "total_cost": 0.01,  # non-zero USD cost
+        },
+    }
+    result = await calculate_cost(response, max_cost=100000)
+
+    assert isinstance(result, CostData)
+    # NOT refunded — the USD cost is billed in full. Pinning the exact value
+    # guards against any future regression that would over-refund a cache-only
+    # turn (the bug in PR #489, which refunded whenever prompt+completion == 0).
+    assert result.total_msats == 200000
+    assert result.total_usd == 0.01
+    assert result.cache_read_input_tokens == 1000
+
+
+# ============================================================================
 # Test 13: Missing Usage Block
 # ============================================================================
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When an upstream reports a non-zero USD cost but the response carries **no tokens at all** — `input`, `output`, `cache_read` and `cache_creation` all zero — the USD-cost path in `calculate_cost` billed the user the full USD-derived amount for an empty response. This patch returns an all-zero cost (full refund) for that case only.

**Supersedes #489**, which is 110 commits behind a refactored `main`, conflicts, and ships no tests. This is a clean re-implementation against current `main`.

## The bug (confirmed on current `main`)

In `routstr/payment/cost_calculation.py`, the `usd_cost > 0` branch logs a warning when `input_tokens == 0 and output_tokens == 0` but then unconditionally falls through to `_calculate_from_usd_cost`, which sets `total_msats = cost_in_msats`. A truly empty response is therefore charged the full USD cost.

## The fix, and the tightened gate vs #489

PR #489 refunded whenever prompt + completion tokens were zero. That **over-fires**: a cache-read-only (or cache-creation-only) turn legitimately reports zero prompt/completion tokens with a real cost and must still be billed — #489 would have refunded those legitimate charges for free.

This patch refunds **only when every token bucket is zero**:

```python
truly_empty = (
    input_tokens == 0
    and output_tokens == 0
    and cache_read_tokens == 0
    and cache_creation_tokens == 0
)
```

A cache-only turn (`cache_read_tokens > 0` or `cache_creation_tokens > 0`) is unaffected and still billed.

## Tests

Added to `tests/unit/test_cost_calculation_caching.py`:

- `test_truly_empty_usd_cost_response_is_refunded` — 0 input + 0 output + 0 cache tokens with a non-zero USD cost → `total_msats == 0` (full refund). **Fails without the fix** (bills 200000 msats) — independently confirmed by reverting the source hunk.
- `test_cache_read_only_usd_cost_response_is_billed` — `cache_read_tokens > 0`, 0 prompt/completion, non-zero cost → still billed. Permanent guard against re-introducing #489's over-refund.

Verification: `pytest tests/unit` → **352 passed, 1 skipped**; `ruff check .` → clean; `mypy` (changed file) → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
