### PR TITLE
fix(db): increase SQLite busy timeout to 10s

### DIFF
--- a/routstr/core/db.py
+++ b/routstr/core/db.py
@@ -11,7 +11,7 @@ from alembic.config import Config
 from alembic.util.exc import CommandError
 from sqlalchemy import UniqueConstraint, delete
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.ext.asyncio.engine import create_async_engine
+from sqlalchemy.ext.asyncio.engine import AsyncEngine, create_async_engine
 from sqlalchemy.orm import aliased
 from sqlmodel import Field, Relationship, SQLModel, col, func, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -22,8 +22,25 @@ logger = get_logger(__name__)
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///keys.db")
 
+# How long a writer waits for SQLite's single write lock before giving up with
+# SQLITE_BUSY (which surfaces as a 500). Python's sqlite3 driver defaults to 5s;
+# on the financial hot path, tiny writes serialise in milliseconds, so a longer
+# wait absorbs bursts of write contention without masking a genuinely stuck
+# writer. Shared with the test engines so lock contention behaves identically in
+# tests as in production.
+SQLITE_BUSY_TIMEOUT_SECONDS = 10
 
-engine = create_async_engine(DATABASE_URL, echo=False)  # echo=True for debugging SQL
+
+def create_db_engine(database_url: str = DATABASE_URL) -> AsyncEngine:
+    """Build the async SQLite engine with the shared busy timeout applied."""
+    return create_async_engine(
+        database_url,
+        echo=False,  # echo=True for debugging SQL
+        connect_args={"timeout": SQLITE_BUSY_TIMEOUT_SECONDS},
+    )
+
+
+engine = create_db_engine()
 
 
 class ApiKey(SQLModel, table=True):  # type: ignore

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from routstr.core.db import SQLITE_BUSY_TIMEOUT_SECONDS
 from routstr.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -359,6 +360,9 @@ async def integration_engine(test_database_url: str) -> AsyncGenerator[Any, None
         pool_pre_ping=True,
         pool_size=5,
         max_overflow=10,
+        # Match production's busy timeout so write-lock contention (e.g. the
+        # concurrent reservation tests) behaves the same here as in production.
+        connect_args={"timeout": SQLITE_BUSY_TIMEOUT_SECONDS},
     )
 
     # Initialize database schema

--- a/tests/integration/test_engine_busy_timeout.py
+++ b/tests/integration/test_engine_busy_timeout.py
@@ -1,0 +1,24 @@
+"""Covers that the integration engine reproduces production's SQLite busy timeout.
+
+The concurrent-reservation tests rely on the test engine contending on the write
+lock the same way production does; this guards against the fixture silently
+drifting back to sqlite3's shorter default.
+"""
+
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+
+from routstr.core.db import SQLITE_BUSY_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_integration_engine_matches_production_busy_timeout(
+    integration_engine: Any,
+) -> None:
+    async with integration_engine.connect() as conn:
+        result = await conn.execute(text("PRAGMA busy_timeout"))
+        busy_timeout_ms = result.scalar()
+
+    assert busy_timeout_ms == SQLITE_BUSY_TIMEOUT_SECONDS * 1000

--- a/tests/unit/test_db_busy_timeout.py
+++ b/tests/unit/test_db_busy_timeout.py
@@ -1,0 +1,26 @@
+"""Covers the SQLite busy-timeout configuration on the async engine.
+
+Ensures the engine waits for the single SQLite write lock instead of raising
+SQLITE_BUSY immediately, and that the value is shared so test engines reproduce
+the same lock-contention behaviour as production.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from routstr.core.db import SQLITE_BUSY_TIMEOUT_SECONDS, create_db_engine
+
+
+@pytest.mark.asyncio
+async def test_engine_applies_shared_busy_timeout() -> None:
+    engine = create_db_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(text("PRAGMA busy_timeout"))
+            busy_timeout_ms = result.scalar()
+    finally:
+        await engine.dispose()
+
+    assert busy_timeout_ms == SQLITE_BUSY_TIMEOUT_SECONDS * 1000


### PR DESCRIPTION
## What

Python's `sqlite3` driver (and therefore `aiosqlite`) defaults to a **5s** busy timeout, so a writer waiting for SQLite's single write lock gives up with `SQLITE_BUSY` — surfaced as a 500 — after only 5s of write contention. This bumps it to **10s**.

On the financial hot path, write transactions are tiny (e.g. the reserve `UPDATE` commits in `auth.py` *before* the upstream network call, so no write transaction spans a network `await`). Locks are therefore always short-held, and a longer wait absorbs bursts of concurrent writes without masking a genuinely stuck writer. 10s doubles the existing headroom; a much larger value would only help if a writer legitimately held the lock for that long — which doesn't happen here — while worsening resource-pinning and detection latency under overload.

## How

- Extract `create_db_engine()` and a shared `SQLITE_BUSY_TIMEOUT_SECONDS` constant in `core/db.py`; the module engine is built through it.
- Apply the same timeout to the integration test engine so the concurrent-reservation tests reproduce production lock-contention behaviour rather than the driver default.

## Tests

- `tests/unit/test_db_busy_timeout.py` — asserts the engine reports `PRAGMA busy_timeout == 10000`.
- `tests/integration/test_engine_busy_timeout.py` — guards the integration engine against silently drifting back to the default.

`make lint` clean (ruff + mypy); `make test-fast` = 668 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)