### PR TITLE
fix: record admin withdrawals as outgoing transactions

### DIFF
--- a/routstr/core/admin.py
+++ b/routstr/core/admin.py
@@ -28,6 +28,7 @@ from .db import (
     ModelRow,
     UpstreamProviderRow,
     create_session,
+    store_cashu_transaction,
 )
 from .log_manager import log_manager
 from .logging import get_logger
@@ -411,12 +412,11 @@ async def withdraw(
     # Get wallet and check balance
     from .settings import settings as global_settings
 
-    wallet = await get_wallet(
-        withdraw_request.mint_url or global_settings.primary_mint, withdraw_request.unit
-    )
+    effective_mint = withdraw_request.mint_url or global_settings.primary_mint
+    wallet = await get_wallet(effective_mint, withdraw_request.unit)
     proofs = get_proofs_per_mint_and_unit(
         wallet,
-        withdraw_request.mint_url or global_settings.primary_mint,
+        effective_mint,
         withdraw_request.unit,
         not_reserved=True,
     )
@@ -432,7 +432,16 @@ async def withdraw(
         raise HTTPException(status_code=400, detail="Insufficient wallet balance")
 
     token = await send_token(
-        withdraw_request.amount, withdraw_request.unit, withdraw_request.mint_url
+        withdraw_request.amount, withdraw_request.unit, effective_mint
+    )
+    await store_cashu_transaction(
+        token=token,
+        amount=withdraw_request.amount,
+        unit=withdraw_request.unit,
+        mint_url=effective_mint,
+        typ="out",
+        collected=False,
+        source="admin",
     )
     return {"token": token}
 

--- a/tests/unit/test_admin_withdraw.py
+++ b/tests/unit/test_admin_withdraw.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from routstr.core import admin
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("requested_mint", [None, "https://secondary.example"])
+async def test_withdraw_uses_effective_mint_and_records_outgoing_transaction(
+    monkeypatch: pytest.MonkeyPatch, requested_mint: str | None
+) -> None:
+    primary_mint = "https://primary.example"
+    effective_mint = requested_mint or primary_mint
+    wallet = object()
+    proofs = [SimpleNamespace(amount=40), SimpleNamespace(amount=60)]
+    token = "cashuBoutgoing"
+
+    get_wallet = AsyncMock(return_value=wallet)
+    get_proofs = Mock(return_value=proofs)
+    filter_proofs = AsyncMock(return_value=proofs)
+    send_token = AsyncMock(return_value=token)
+    store_transaction = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(admin, "get_wallet", get_wallet)
+    monkeypatch.setattr(admin, "get_proofs_per_mint_and_unit", get_proofs)
+    monkeypatch.setattr(admin, "slow_filter_spend_proofs", filter_proofs)
+    monkeypatch.setattr(admin, "send_token", send_token)
+    monkeypatch.setattr(admin, "store_cashu_transaction", store_transaction)
+    monkeypatch.setattr(admin.settings, "primary_mint", primary_mint)
+
+    result = await admin.withdraw(
+        Mock(),
+        admin.WithdrawRequest(amount=75, mint_url=requested_mint, unit="sat"),
+    )
+
+    assert result == {"token": token}
+    get_wallet.assert_awaited_once_with(effective_mint, "sat")
+    get_proofs.assert_called_once_with(wallet, effective_mint, "sat", not_reserved=True)
+    filter_proofs.assert_awaited_once_with(proofs, wallet)
+    send_token.assert_awaited_once_with(75, "sat", effective_mint)
+    store_transaction.assert_awaited_once_with(
+        token=token,
+        amount=75,
+        unit="sat",
+        mint_url=effective_mint,
+        typ="out",
+        collected=False,
+        source="admin",
+    )


### PR DESCRIPTION
## Summary
- resolve and consistently use the effective mint for admin withdrawals
- persist issued withdrawal tokens as outgoing, uncollected Cashu transactions
- cover explicit and default mint paths

## Test plan
- `uv run pytest tests/unit/test_admin_withdraw.py -q`
- `uv run ruff check routstr/core/admin.py tests/unit/test_admin_withdraw.py`