### PR TITLE
fix: stop DB connection-pool exhaustion in balance reads (+ env-configurable pool sizing)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,38 @@ ROUTSTR_SECRET_KEY=
 # Database
 # DATABASE_URL=sqlite+aiosqlite:///keys.db
 
+# Database tuning (advanced — you almost certainly do not need these)
+# ---------------------------------------------------------------------------
+# These size the SQLAlchemy connection pool. The defaults below match
+# SQLAlchemy's own baseline, so leaving them unset changes nothing. Touch them
+# ONLY if the logs show the pool running out of connections:
+#
+#     QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
+#
+# The effective values are printed at startup ("Database pool configured: ...")
+# so you can confirm what is actually in effect while diagnosing an incident.
+# An invalid value (non-integer, or a pool size below 1) stops the node at boot
+# with a clear error rather than starting up misconfigured.
+#
+# DATABASE_POOL_SIZE      Connections kept open in the pool.        (default 5)
+# DATABASE_MAX_OVERFLOW   Extra connections opened under load,      (default 10)
+#                         beyond pool_size, then discarded.
+# DATABASE_POOL_TIMEOUT   Seconds a request waits for a free        (default 30)
+#                         connection before failing with the error above.
+#
+# Note for the default SQLite backend: SQLite serialises writes behind a single
+# database-level lock, so a bigger pool does NOT buy more write throughput — it
+# only lets more readers run at once (WAL mode) and trades pool-timeout errors
+# for "database is locked" errors. If you exhaust the pool on SQLite, the cause
+# is almost always connections being held too long, not the pool being too
+# small. These knobs come into their own if you point DATABASE_URL at a
+# networked database (e.g. Postgres), where connections genuinely run in
+# parallel; there, size the pool against the server's max_connections.
+#
+# DATABASE_POOL_SIZE=5
+# DATABASE_MAX_OVERFLOW=10
+# DATABASE_POOL_TIMEOUT=30
+
 # Node Information
 # NAME=My Routstr Node
 # DESCRIPTION=Fast AI API access with Bitcoin payments

--- a/routstr/core/db.py
+++ b/routstr/core/db.py
@@ -13,7 +13,9 @@ from alembic import command
 from alembic.config import Config
 from alembic.util.exc import CommandError
 from sqlalchemy import Index, UniqueConstraint, case, delete, or_
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.asyncio.engine import create_async_engine
 from sqlalchemy.orm import aliased
 from sqlmodel import Field, Relationship, SQLModel, col, func, select, update
@@ -26,7 +28,48 @@ logger = get_logger(__name__)
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///keys.db")
 
 
-engine = create_async_engine(DATABASE_URL, echo=False)  # echo=True for debugging SQL
+def create_db_engine(database_url: str = DATABASE_URL) -> AsyncEngine:
+    """Build the async engine, sizing the connection pool from ``settings``.
+
+    Pool sizing comes from the pydantic ``Settings`` (validated at boot like
+    every other typed env var), so an out-of-range value refuses to start rather
+    than running misconfigured. Defaults match SQLAlchemy's own baseline
+    (5 / 10 / 30s); operators only need to tune them when logs show
+    ``QueuePool limit ... reached, connection timed out`` — see the "Database
+    tuning" section of ``.env.example``. The effective config is logged so it can
+    be confirmed from the boot output during an incident.
+
+    In-memory SQLite is a special case: it uses ``StaticPool``, which rejects
+    the pool-sizing kwargs (passing them raises ``TypeError``), and there is no
+    pool to size anyway — so those URLs are built without them.
+    """
+    from .settings import settings
+
+    url = make_url(database_url)
+    is_memory_sqlite = url.get_backend_name() == "sqlite" and url.database in (
+        None,
+        "",
+        ":memory:",
+    )
+    if is_memory_sqlite:
+        logger.info("Database pool: in-memory SQLite, using default StaticPool")
+        return create_async_engine(database_url, echo=False)
+
+    logger.info(
+        f"Database pool configured: pool_size={settings.database_pool_size} "
+        f"max_overflow={settings.database_max_overflow} "
+        f"pool_timeout={settings.database_pool_timeout}s",
+    )
+    return create_async_engine(  # echo=True for debugging SQL
+        database_url,
+        echo=False,
+        pool_size=settings.database_pool_size,
+        max_overflow=settings.database_max_overflow,
+        pool_timeout=settings.database_pool_timeout,
+    )
+
+
+engine = create_db_engine()
 
 
 class ApiKey(SQLModel, table=True):  # type: ignore

--- a/routstr/core/db.py
+++ b/routstr/core/db.py
@@ -717,14 +717,37 @@ async def complete_routstr_fee_payout(
     return result.rowcount == 1
 
 
-async def balances_for_mint_and_unit(
-    db_session: AsyncSession, mint_url: str, unit: str
-) -> int:
-    query = select(func.sum(ApiKey.balance)).where(
-        ApiKey.refund_mint_url == mint_url, ApiKey.refund_currency == unit
+async def balances_by_mint_and_unit(
+    db_session: AsyncSession, mint_urls: list[str], units: list[str]
+) -> dict[tuple[str, str], int]:
+    """Sum outstanding user balances (msats) grouped by (mint_url, unit).
+
+    One query for every requested mint/unit pair. Pairs with no matching rows
+    are absent from the mapping — callers should default those to 0.
+    """
+    if not mint_urls or not units:
+        return {}
+    query = (
+        select(
+            ApiKey.refund_mint_url,
+            ApiKey.refund_currency,
+            func.sum(ApiKey.balance),
+        )
+        .where(
+            col(ApiKey.refund_mint_url).in_(mint_urls),
+            col(ApiKey.refund_currency).in_(units),
+        )
+        .group_by(col(ApiKey.refund_mint_url), col(ApiKey.refund_currency))
     )
     result = await db_session.exec(query)
-    return result.one() or 0
+    # IN(...) filters out NULL mint_url/currency at the SQL level, so the group
+    # keys are never None at runtime; the guard also narrows the nullable
+    # columns from ``str | None`` to ``str`` for the typed return.
+    return {
+        (mint_url, unit): total or 0
+        for mint_url, unit, total in result.all()
+        if mint_url is not None and unit is not None
+    }
 
 
 async def init_db() -> None:

--- a/routstr/core/settings.py
+++ b/routstr/core/settings.py
@@ -100,6 +100,14 @@ class Settings(BaseSettings):
     refund_cache_ttl_seconds: int = Field(default=3600, env="REFUND_CACHE_TTL_SECONDS")
     refund_sweep_ttl_seconds: int = Field(default=604800, env="REFUND_SWEEP_TTL_SECONDS")
 
+    # Database connection-pool sizing (advanced). Defaults match SQLAlchemy's own
+    # baseline, so unset is behaviour-neutral — see the "Database tuning" section
+    # of .env.example. A pool_size of 0 would mean an unbounded pool in
+    # SQLAlchemy, so it is rejected (ge=1); max_overflow=0 (no overflow) is valid.
+    database_pool_size: int = Field(default=5, ge=1, env="DATABASE_POOL_SIZE")
+    database_max_overflow: int = Field(default=10, ge=0, env="DATABASE_MAX_OVERFLOW")
+    database_pool_timeout: int = Field(default=30, ge=1, env="DATABASE_POOL_TIMEOUT")
+
     # Logging
     log_level: str = Field(default="INFO", env="LOG_LEVEL")
     enable_console_logging: bool = Field(default=True, env="ENABLE_CONSOLE_LOGGING")
@@ -144,10 +152,25 @@ def _normalize_settings_data(data: dict[str, Any]) -> dict[str, Any]:
 # ``routstr.core.vault``.
 SECRET_FIELDS = frozenset({"admin_password", "nsec"})
 
+# Infrastructure the node needs *before* it can open a DB session — so it can
+# never be configured from the DB (chicken-and-egg) and stays env-only. Unlike
+# secrets (owned by bootstrap), these are excluded so the DB settings blob can
+# neither store nor shadow them; env is always authoritative.
+ENV_ONLY_FIELDS = frozenset(
+    {"database_pool_size", "database_max_overflow", "database_pool_timeout"}
+)
+
+_NON_PERSISTED_FIELDS = SECRET_FIELDS | ENV_ONLY_FIELDS
+
 
 def _strip_secret_fields(data: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of ``data`` without any secret fields (for persistence)."""
-    return {k: v for k, v in data.items() if k not in SECRET_FIELDS}
+    """Return a copy of ``data`` without secret or env-only fields.
+
+    Both are kept out of the persisted settings blob: secrets for confidentiality,
+    env-only fields (e.g. DB pool sizing) because they must never be sourced from
+    the database.
+    """
+    return {k: v for k, v in data.items() if k not in _NON_PERSISTED_FIELDS}
 
 
 def _apply_to_live_settings(data: dict[str, Any]) -> None:
@@ -327,7 +350,13 @@ class SettingsService:
             valid_fields = set(env_resolved.dict().keys())
             merged_dict: dict[str, Any] = dict(env_resolved.dict())
             merged_dict.update(
-                {k: v for k, v in db_json.items() if v not in (None, "", [], {}) and k in valid_fields}
+                {
+                    k: v
+                    for k, v in db_json.items()
+                    if v not in (None, "", [], {})
+                    and k in valid_fields
+                    and k not in ENV_ONLY_FIELDS
+                }
             )
             merged_dict = Settings(**merged_dict).dict()
 
@@ -394,8 +423,13 @@ class SettingsService:
                 )
             )
             await db_session.commit()
-            # Update in-place
+            # Update in-place. Env-only fields (e.g. DB pool sizing) are never
+            # applied here: the engine pool is already built at boot from env,
+            # so letting an update mutate the live value would only make it
+            # diverge from the running pool.
             for k, v in candidate.dict().items():
+                if k in ENV_ONLY_FIELDS:
+                    continue
                 setattr(settings, k, v)
             cls._current = settings
             return settings

--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -837,7 +837,7 @@ async def fetch_all_balances(
         units = ["sat", "msat"]
 
     async def fetch_balance(
-        session: db.AsyncSession, mint_url: str, unit: str
+        mint_url: str, unit: str, user_balance: int
     ) -> BalanceDetail:
         try:
             wallet = await get_wallet(mint_url, unit)
@@ -845,7 +845,6 @@ async def fetch_all_balances(
                 wallet, mint_url, unit, not_reserved=True
             )
             proofs = await slow_filter_spend_proofs(proofs, wallet)
-            user_balance = await db.balances_for_mint_and_unit(session, mint_url, unit)
             if unit == "sat":
                 user_balance = user_balance // 1000
             proofs_balance = sum(proof.amount for proof in proofs)
@@ -878,40 +877,66 @@ async def fetch_all_balances(
     if settings.primary_mint and settings.primary_mint not in mint_urls:
         mint_urls.append(settings.primary_mint)
 
-    # Create tasks for all mint/unit combinations
-    async with db.create_session() as session:
-        tasks = [
-            fetch_balance(session, mint_url, unit)
-            for mint_url in mint_urls
-            for unit in units
-        ]
+    # Read all outstanding user liabilities up front in one short-lived DB
+    # session and a single grouped query. AsyncSession is not safe for
+    # concurrent use, so the session must NOT be shared across the gathered
+    # mint checks below (that raises "concurrent operations are not permitted"
+    # and can wedge connections until the pool is exhausted). A DB failure here
+    # must still degrade gracefully rather than 500 the whole balances page.
+    user_balances: dict[tuple[str, str], int] = {}
+    liabilities_error: str | None = None
+    try:
+        async with db.create_session() as session:
+            user_balances = await db.balances_by_mint_and_unit(
+                session, mint_urls, units
+            )
+    except Exception as e:
+        logger.error(f"Error reading user balances: {e}")
+        liabilities_error = str(e)
 
-        # Run all tasks concurrently
-        balance_details = list(await asyncio.gather(*tasks))
+    # Run the per-mint balance checks concurrently — no DB session involved.
+    tasks = [
+        fetch_balance(mint_url, unit, user_balances.get((mint_url, unit), 0))
+        for mint_url in mint_urls
+        for unit in units
+    ]
+    balance_details = list(await asyncio.gather(*tasks))
 
-    # Calculate totals
+    # Compute totals BEFORE tagging any liability-read failure. A failed
+    # liability read does not invalidate custody, so the known wallet balance
+    # must still be summed; only the per-user split is unknowable. A per-mint
+    # fetch failure (``error`` already set inside fetch_balance) means custody
+    # for that mint is genuinely unknown, so those details are skipped.
     total_wallet_balance_sats = 0
     total_user_balance_sats = 0
-
     for detail in balance_details:
-        if not detail.get("error"):
-            # Convert to sats for total calculation
-            unit = detail["unit"]
-            proofs_balance_sats = (
-                detail["wallet_balance"]
-                if unit == "sat"
-                else detail["wallet_balance"] // 1000
-            )
-            user_balance_sats = (
+        if detail.get("error"):
+            continue
+        unit = detail["unit"]
+        total_wallet_balance_sats += (
+            detail["wallet_balance"]
+            if unit == "sat"
+            else detail["wallet_balance"] // 1000
+        )
+        if liabilities_error is None:
+            total_user_balance_sats += (
                 detail["user_balance"]
                 if unit == "sat"
                 else detail["user_balance"] // 1000
             )
 
-            total_wallet_balance_sats += proofs_balance_sats
-            total_user_balance_sats += user_balance_sats
-
-    owner_balance = total_wallet_balance_sats - total_user_balance_sats
+    if liabilities_error is None:
+        owner_balance = total_wallet_balance_sats - total_user_balance_sats
+    else:
+        # Liabilities are unknown: report custody truthfully but never claim any
+        # of it as owner profit (owner = wallet - unknown liabilities). Surface
+        # the failure on each detail without discarding a more specific per-mint
+        # error, and blank the unknowable per-user/owner split.
+        owner_balance = 0
+        for detail in balance_details:
+            detail["user_balance"] = 0
+            detail["owner_balance"] = 0
+            detail.setdefault("error", liabilities_error)
 
     return (
         balance_details,
@@ -935,9 +960,10 @@ async def periodic_payout() -> None:
             if settings.primary_mint and settings.primary_mint not in mint_urls:
                 mint_urls.append(settings.primary_mint)
 
+            units = ["sat", "msat"]
             async with db.create_session() as session:
                 for mint_url in mint_urls:
-                    for unit in ["sat", "msat"]:
+                    for unit in units:
                         # Isolate failures per mint/unit so one slow or failing
                         # mint does not abort payout for every other mint/unit.
                         try:
@@ -947,9 +973,17 @@ async def periodic_payout() -> None:
                             )
                             proofs = await slow_filter_spend_proofs(proofs, wallet)
                             await asyncio.sleep(5)
-                            user_balance = await db.balances_for_mint_and_unit(
-                                session, mint_url, unit
+                            # Read the liability fresh, right before deciding the
+                            # payout. The mint round-trip above is slow; reading
+                            # it once before the loop would let a user top-up
+                            # during the cycle go unseen, so a later (mint, unit)
+                            # would act on a stale-low liability and over-send
+                            # funds owed to users. The loop is sequential, so
+                            # reusing this session per iteration is safe.
+                            balances = await db.balances_by_mint_and_unit(
+                                session, [mint_url], [unit]
                             )
+                            user_balance = balances.get((mint_url, unit), 0)
                             if unit == "sat":
                                 user_balance = user_balance // 1000
                             proofs_balance = sum(proof.amount for proof in proofs)

--- a/tests/unit/test_balances_by_mint_and_unit.py
+++ b/tests/unit/test_balances_by_mint_and_unit.py
@@ -1,0 +1,100 @@
+"""Real-DB coverage for db.balances_by_mint_and_unit.
+
+Verifies the grouped liability query used by fetch_all_balances: it sums
+balances per (mint_url, unit), filters to the requested mints/units, excludes
+NULL mint/currency rows, and returns nothing for empty inputs.
+"""
+
+from typing import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from routstr.core.db import ApiKey, balances_by_mint_and_unit
+
+
+def _make_engine() -> AsyncEngine:
+    return create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+
+@pytest.fixture
+async def session() -> "AsyncGenerator[AsyncSession, None]":
+    engine = _make_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    db_session = AsyncSession(engine, expire_on_commit=False)
+    try:
+        yield db_session
+    finally:
+        await db_session.close()
+        await engine.dispose()
+
+
+async def _add_key(
+    session: AsyncSession,
+    hashed_key: str,
+    balance: int,
+    mint_url: str | None,
+    currency: str | None,
+) -> None:
+    session.add(
+        ApiKey(
+            hashed_key=hashed_key,
+            balance=balance,
+            refund_mint_url=mint_url,
+            refund_currency=currency,
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_sums_and_groups_by_mint_and_unit(session: AsyncSession) -> None:
+    await _add_key(session, "a", 1000, "http://m1", "sat")
+    await _add_key(session, "b", 500, "http://m1", "sat")
+    await _add_key(session, "c", 7000, "http://m1", "msat")
+    await _add_key(session, "d", 200, "http://m2", "sat")
+
+    result = await balances_by_mint_and_unit(
+        session, ["http://m1", "http://m2"], ["sat", "msat"]
+    )
+
+    assert result[("http://m1", "sat")] == 1500
+    assert result[("http://m1", "msat")] == 7000
+    assert result[("http://m2", "sat")] == 200
+
+
+@pytest.mark.asyncio
+async def test_filters_out_unrequested_mints_and_units(session: AsyncSession) -> None:
+    await _add_key(session, "a", 1000, "http://wanted", "sat")
+    await _add_key(session, "b", 999, "http://other", "sat")
+    await _add_key(session, "c", 888, "http://wanted", "usd")
+
+    result = await balances_by_mint_and_unit(session, ["http://wanted"], ["sat"])
+
+    assert result == {("http://wanted", "sat"): 1000}
+
+
+@pytest.mark.asyncio
+async def test_excludes_rows_with_null_mint_or_currency(session: AsyncSession) -> None:
+    await _add_key(session, "a", 1000, "http://m1", "sat")
+    await _add_key(session, "b", 4242, None, None)
+
+    result = await balances_by_mint_and_unit(session, ["http://m1"], ["sat"])
+
+    assert result == {("http://m1", "sat"): 1000}
+
+
+@pytest.mark.asyncio
+async def test_empty_inputs_return_empty_mapping(session: AsyncSession) -> None:
+    await _add_key(session, "a", 1000, "http://m1", "sat")
+
+    assert await balances_by_mint_and_unit(session, [], ["sat"]) == {}
+    assert await balances_by_mint_and_unit(session, ["http://m1"], []) == {}

--- a/tests/unit/test_db_pool_config.py
+++ b/tests/unit/test_db_pool_config.py
@@ -1,0 +1,129 @@
+"""Coverage for env-configurable DB connection-pool sizing.
+
+Pool sizing comes from the pydantic ``Settings`` (DATABASE_POOL_SIZE /
+DATABASE_MAX_OVERFLOW / DATABASE_POOL_TIMEOUT), matching how every other typed
+env var is consumed. Defaults equal SQLAlchemy's own baseline so unset is
+behaviour-neutral; a bad value fails validation and refuses to boot (like a
+malformed DATABASE_URL); the effective config is logged at engine creation; and
+pool_pre_ping is never enabled (the default DB is a local SQLite file with no
+network peer to drop idle connections). In-memory SQLite uses StaticPool, which
+rejects the pool kwargs, so those URLs are built without them.
+"""
+
+import logging
+
+import pytest
+from pydantic.v1 import ValidationError
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.pool import QueuePool, StaticPool
+
+from routstr.core.db import create_db_engine
+from routstr.core.settings import Settings, settings
+
+# A file URL keeps the pool an AsyncAdaptedQueuePool (which honours pool_size);
+# engine creation is lazy, so no connection is opened and no file is created.
+_URL = "sqlite+aiosqlite:///./_pool_config_test.db"
+
+
+def _pool(engine: AsyncEngine) -> QueuePool:
+    pool = engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    return pool
+
+
+def test_pool_defaults_match_sqlalchemy_baseline() -> None:
+    """With defaults, the pool keeps SQLAlchemy's 5 / 10 / 30 baseline."""
+    pool = _pool(create_db_engine(_URL))
+    assert pool.size() == 5
+    assert pool._max_overflow == 10
+    assert pool._timeout == 30
+
+
+def test_pool_config_reads_settings_overrides() -> None:
+    """create_db_engine sizes the pool from the Settings values."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(settings, "database_pool_size", 3)
+        mp.setattr(settings, "database_max_overflow", 7)
+        mp.setattr(settings, "database_pool_timeout", 12)
+
+        pool = _pool(create_db_engine(_URL))
+
+    assert pool.size() == 3
+    assert pool._max_overflow == 7
+    assert pool._timeout == 12
+
+
+@pytest.mark.parametrize("url", ["sqlite+aiosqlite://", "sqlite+aiosqlite:///:memory:"])
+def test_in_memory_sqlite_skips_pool_sizing(url: str) -> None:
+    """In-memory SQLite uses StaticPool, which rejects pool kwargs.
+
+    Passing pool_size/max_overflow/pool_timeout to such a URL raises TypeError,
+    so create_db_engine must not send them — the engine must build cleanly.
+    """
+    engine = create_db_engine(url)
+    assert isinstance(engine.sync_engine.pool, StaticPool)
+
+
+def test_pool_does_not_enable_pre_ping() -> None:
+    """pre_ping stays off: the local SQLite file has no peer to drop connections."""
+    assert _pool(create_db_engine(_URL))._pre_ping is False
+
+
+def test_engine_creation_logs_effective_pool_config(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The effective pool config is logged so operators can confirm it at boot."""
+    # The routstr loggers set propagate=False, so caplog's root handler never
+    # sees the record — attach the capture handler to this logger directly.
+    db_logger = logging.getLogger("routstr.core.db")
+    db_logger.addHandler(caplog.handler)
+    db_logger.setLevel(logging.INFO)
+    try:
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings, "database_pool_size", 4)
+            mp.setattr(settings, "database_max_overflow", 9)
+            mp.setattr(settings, "database_pool_timeout", 15)
+            create_db_engine(_URL)
+    finally:
+        db_logger.removeHandler(caplog.handler)
+
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "pool_size" in logged
+    assert "4" in logged and "9" in logged and "15" in logged
+
+
+# --- Validation happens in Settings (pydantic), like every other typed env var.
+# A bad value raises ValidationError when Settings is built at boot, refusing to
+# start rather than running misconfigured.
+
+
+def test_non_integer_pool_size_rejected_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_POOL_SIZE", "twenty")
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+@pytest.mark.parametrize("value", ["0", "-3"])
+def test_out_of_range_pool_size_rejected_at_boot(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """pool_size below 1 is rejected: 0 would mean an unbounded pool."""
+    monkeypatch.setenv("DATABASE_POOL_SIZE", value)
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_negative_pool_timeout_rejected_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_POOL_TIMEOUT", "0")
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_zero_max_overflow_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """max_overflow=0 (no overflow) is a valid choice, not a rejection trigger."""
+    monkeypatch.setenv("DATABASE_MAX_OVERFLOW", "0")
+    assert Settings().database_max_overflow == 0

--- a/tests/unit/test_fetch_all_balances.py
+++ b/tests/unit/test_fetch_all_balances.py
@@ -1,4 +1,7 @@
-from contextlib import asynccontextmanager
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,9 +14,70 @@ async def _fake_session():  # type: ignore[no-untyped-def]
     yield MagicMock()
 
 
-def _patches(  # type: ignore[no-untyped-def]
-    proof_amount: int = 1000, user_balance_msats: int = 0
-):
+class _TrackingSession:
+    """Stand-in for ``AsyncSession`` that records concurrent use.
+
+    Real ``AsyncSession`` is not safe for concurrent use: if a second
+    coroutine issues a query while an ``await``-ed query is still in flight
+    on the same session it raises ``"This session is provisioning a new
+    connection; concurrent operations are not permitted"`` and can leave a
+    connection wedged.
+
+    Every awaited query method (``exec``, ``execute``, ``scalar``, ``get`` …)
+    is resolved through ``__getattr__`` to the same tracked coroutine, so the
+    double detects concurrent use regardless of which session API the code
+    under test happens to call — it counts how many coroutines are inside a
+    query at once and remembers the peak.
+    """
+
+    def __init__(self) -> None:
+        self._in_flight = 0
+        self.max_concurrency = 0
+        self.query_calls = 0
+
+    def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
+        async def _tracked(*args: object, **kwargs: object) -> MagicMock:
+            self.query_calls += 1
+            self._in_flight += 1
+            self.max_concurrency = max(self.max_concurrency, self._in_flight)
+            try:
+                # Yield to the event loop so any concurrently-scheduled task
+                # sharing this session can enter a query before we exit.
+                await asyncio.sleep(0.01)
+                result = MagicMock()
+                result.one.return_value = 0
+                result.all.return_value = []
+                return result
+            finally:
+                self._in_flight -= 1
+
+        return _tracked
+
+
+def _tracking_session_factory() -> tuple[
+    Callable[[], AbstractAsyncContextManager[_TrackingSession]],
+    list[_TrackingSession],
+]:
+    """Patch replacement for ``db.create_session`` that records every session.
+
+    Each ``async with db.create_session()`` gets a fresh ``_TrackingSession``,
+    appended to ``sessions`` so the test can assert that *no single* session
+    was ever used concurrently — true whether the fix precomputes balances in
+    one query (one session, used serially) or opens a session per task.
+    """
+    sessions: list[_TrackingSession] = []
+
+    @asynccontextmanager
+    async def _factory() -> "AsyncIterator[_TrackingSession]":
+        session = _TrackingSession()
+        sessions.append(session)
+        yield session
+
+    return _factory, sessions
+
+
+def _mint_patches(proof_amount: int = 1000):  # type: ignore[no-untyped-def]
+    """Patches for the mint/proof side of ``fetch_all_balances`` (no DB)."""
     proof = MagicMock(amount=proof_amount)
     return [
         patch("routstr.wallet.get_wallet", AsyncMock(return_value=MagicMock())),
@@ -25,9 +89,21 @@ def _patches(  # type: ignore[no-untyped-def]
             "routstr.wallet.slow_filter_spend_proofs",
             AsyncMock(side_effect=lambda proofs, wallet: proofs),
         ),
+    ]
+
+
+def _patches(  # type: ignore[no-untyped-def]
+    proof_amount: int = 1000, user_balance_msats: int = 0
+):
+    async def _grouped(  # type: ignore[no-untyped-def]
+        session: object, mint_urls: list[str], units: list[str]
+    ):
+        return {(m, u): user_balance_msats for m in mint_urls for u in units}
+
+    return _mint_patches(proof_amount) + [
         patch(
-            "routstr.wallet.db.balances_for_mint_and_unit",
-            AsyncMock(return_value=user_balance_msats),
+            "routstr.wallet.db.balances_by_mint_and_unit",
+            AsyncMock(side_effect=_grouped),
         ),
         patch("routstr.wallet.db.create_session", _fake_session),
     ]
@@ -77,6 +153,137 @@ async def test_fetch_all_balances_reports_liability_when_wallet_is_empty() -> No
     assert total_wallet == 0
     assert total_user == 5
     assert owner == -5
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_balances_does_not_use_one_session_concurrently() -> None:
+    """A single AsyncSession must never be shared across the gathered tasks.
+
+    ``fetch_all_balances`` fans out one balance lookup per (mint, unit) with
+    ``asyncio.gather``. Passing one session into all of them makes concurrent
+    coroutines issue queries on the same AsyncSession — unsafe, and the source
+    of the observed "concurrent operations are not permitted" error that
+    cascades into connection-pool exhaustion.
+
+    We drive it with several mint/unit combinations and a session whose
+    ``exec`` records peak concurrency. If any session is entered by more than
+    one coroutine at a time the finding is present.
+    """
+    from routstr.core.settings import settings
+
+    factory, sessions = _tracking_session_factory()
+
+    # NB: db.balances_by_mint_and_unit is intentionally NOT patched here — we
+    # let the real helper run so it issues a query on the session, which is
+    # what exercises (and detects) concurrent session use.
+    patches = _mint_patches() + [
+        patch("routstr.wallet.db.create_session", factory),
+    ]
+
+    with patch.object(
+        settings, "cashu_mints", ["http://mint-a:3338", "http://mint-b:3338"]
+    ), patch.object(settings, "primary_mint", "http://mint-a:3338"):
+        for p in patches:
+            p.start()
+        try:
+            await fetch_all_balances(units=["sat", "msat"])
+        finally:
+            patch.stopall()
+
+    # The liabilities must be read in exactly ONE short-lived session with ONE
+    # query, before the concurrent mint fan-out — not a session per gathered
+    # task, and never a session shared across tasks. Asserting the exact shape
+    # (rather than a peak-concurrency counter, which cannot trip once no session
+    # crosses the gather) makes the guarantee explicit and catches a regression
+    # that reintroduces per-task DB access.
+    assert len(sessions) == 1, (
+        f"expected exactly one create_session() for the up-front liability read, "
+        f"got {len(sessions)}"
+    )
+    assert sessions[0].query_calls == 1, (
+        f"expected a single grouped liability query, got "
+        f"{sessions[0].query_calls} — per-(mint,unit) querying has returned"
+    )
+    # And that single session was never entered concurrently.
+    assert sessions[0].max_concurrency <= 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_balances_degrades_when_liability_read_fails() -> None:
+    """A DB failure reading liabilities must not 500 the whole balances page.
+
+    A failed liability read does not invalidate custody, so the *known* wallet
+    balance is still reported (both per-mint and in the wallet total). Only the
+    unknowable per-user/owner split is blanked, and owner is reported as 0 so
+    the custody is never claimed as owner profit.
+    """
+    from routstr.core.settings import settings
+
+    patches = _mint_patches(proof_amount=1000) + [
+        patch(
+            "routstr.wallet.db.balances_by_mint_and_unit",
+            AsyncMock(side_effect=RuntimeError("db pool exhausted")),
+        ),
+        patch("routstr.wallet.db.create_session", _fake_session),
+    ]
+
+    with patch.object(settings, "cashu_mints", []), patch.object(
+        settings, "primary_mint", "http://primary:3338"
+    ):
+        for p in patches:
+            p.start()
+        try:
+            details, total_wallet, total_user, owner = await fetch_all_balances(
+                units=["sat"]
+            )
+        finally:
+            patch.stopall()
+
+    assert details[0]["error"] == "db pool exhausted"
+    assert details[0]["user_balance"] == 0
+    assert details[0]["owner_balance"] == 0
+    # Custody is known and must not be hidden by the liability-read failure.
+    assert details[0]["wallet_balance"] == 1000
+    assert total_wallet == 1000
+    # The user/owner split is unknown: blanked, and never claimed as profit.
+    assert total_user == 0
+    assert owner == 0
+
+
+@pytest.mark.asyncio
+async def test_liability_error_does_not_clobber_a_specific_mint_error() -> None:
+    """A per-mint fetch failure keeps its specific error under a liability error.
+
+    When the up-front liability read fails, every detail is tagged so the UI
+    shows liabilities are unknown — but a detail that already failed at the mint
+    level carries a more specific message, which must not be overwritten by the
+    generic liability-read error.
+    """
+    from routstr.core.settings import settings
+
+    patches: list[Any] = [
+        patch(
+            "routstr.wallet.get_wallet",
+            AsyncMock(side_effect=RuntimeError("mint down")),
+        ),
+        patch(
+            "routstr.wallet.db.balances_by_mint_and_unit",
+            AsyncMock(side_effect=RuntimeError("db pool exhausted")),
+        ),
+        patch("routstr.wallet.db.create_session", _fake_session),
+    ]
+
+    with patch.object(settings, "cashu_mints", []), patch.object(
+        settings, "primary_mint", "http://primary:3338"
+    ):
+        for p in patches:
+            p.start()
+        try:
+            details, *_ = await fetch_all_balances(units=["sat"])
+        finally:
+            patch.stopall()
+
+    assert details[0]["error"] == "mint down"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_periodic_payout.py
+++ b/tests/unit/test_periodic_payout.py
@@ -74,7 +74,7 @@ async def test_periodic_payout_includes_primary_mint_not_in_cashu_mints() -> Non
         "routstr.wallet.slow_filter_spend_proofs",
         AsyncMock(side_effect=lambda proofs, wallet: proofs),
     ), patch(
-        "routstr.wallet.db.balances_for_mint_and_unit", AsyncMock(return_value=0)
+        "routstr.wallet.db.balances_by_mint_and_unit", AsyncMock(return_value={})
     ), patch("routstr.wallet.raw_send_to_lnurl", raw_send):
         with pytest.raises(_LoopBreak):
             await periodic_payout()
@@ -112,7 +112,7 @@ async def test_periodic_payout_isolates_failing_mint() -> None:
         "routstr.wallet.slow_filter_spend_proofs",
         AsyncMock(side_effect=lambda proofs, wallet: proofs),
     ), patch(
-        "routstr.wallet.db.balances_for_mint_and_unit", AsyncMock(return_value=0)
+        "routstr.wallet.db.balances_by_mint_and_unit", AsyncMock(return_value={})
     ), patch("routstr.wallet.raw_send_to_lnurl", raw_send):
         with pytest.raises(_LoopBreak):
             await periodic_payout()
@@ -124,6 +124,63 @@ async def test_periodic_payout_isolates_failing_mint() -> None:
     ]
     assert len(good_calls) == 2  # sat + msat
     assert raw_send.await_count == 2  # good mint paid for both units
+
+
+@pytest.mark.asyncio
+async def test_periodic_payout_reads_liability_fresh_per_iteration() -> None:
+    """The liability must be read fresh inside the loop, after the mint round-trip.
+
+    Reading all liabilities once *before* the loop lets a user top-up during the
+    slow, per-mint payout cycle go unseen: a later (mint, unit) then computes
+    ``available_balance = fresh_proofs - stale_liability`` and can over-send
+    funds owed to users. The read must happen per (mint, unit), after the inner
+    ``asyncio.sleep(5)``, so it reflects the balance at payout time.
+    """
+    from routstr.core.settings import settings
+
+    events: list[str] = []
+
+    async def _sleep(seconds: float) -> None:
+        if seconds == _INTERVAL:
+            events.append("interval")
+            if events.count("interval") >= 2:
+                raise _LoopBreak()
+        else:
+            events.append(f"sleep{int(seconds)}")
+
+    async def _liability(
+        session: Any, mint_urls: list[str], units: list[str]
+    ) -> dict[tuple[str, str], int]:
+        events.append("liability")
+        return {}
+
+    with patch.object(settings, "cashu_mints", ["http://m:3338"]), patch.object(
+        settings, "primary_mint", "http://m:3338"
+    ), patch.object(settings, "receive_ln_address", "owner@ln.tld"), patch.object(
+        settings, "payout_interval_seconds", _INTERVAL
+    ), patch.object(settings, "min_payout_sat", 10), patch(
+        "routstr.wallet.asyncio.sleep", _sleep
+    ), patch("routstr.wallet.db.create_session", _fake_session), patch(
+        "routstr.wallet.get_wallet", AsyncMock(return_value=MagicMock())
+    ), patch(
+        "routstr.wallet.get_proofs_per_mint_and_unit",
+        MagicMock(return_value=[MagicMock(amount=100_000)]),
+    ), patch(
+        "routstr.wallet.slow_filter_spend_proofs",
+        AsyncMock(side_effect=lambda proofs, wallet: proofs),
+    ), patch(
+        "routstr.wallet.db.balances_by_mint_and_unit",
+        AsyncMock(side_effect=_liability),
+    ), patch("routstr.wallet.raw_send_to_lnurl", AsyncMock(return_value=1000)):
+        with pytest.raises(_LoopBreak):
+            await periodic_payout()
+
+    # One fresh liability read per (mint, unit) pair (sat + msat), not a single
+    # pre-loop snapshot shared across the whole cycle.
+    assert events.count("liability") == 2
+    # And the first read happens only after the first inner mint sleep, proving
+    # it is read inside the loop at payout time rather than before it.
+    assert events.index("liability") > events.index("sleep5")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -62,6 +62,68 @@ def test_payout_settings_have_sensible_defaults() -> None:
     assert s.payout_interval_seconds == 900
 
 
+@pytest.mark.asyncio
+async def test_database_pool_fields_are_env_only_not_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB pool sizing is infrastructure the node needs *before* it can read the
+    DB, so it can never be configured from the DB — it must never be written to
+    the settings blob, and a stale/injected DB value must never shadow env.
+    """
+    monkeypatch.setenv("DATABASE_POOL_SIZE", "7")
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        s = await SettingsService.initialize(session)
+
+        # The env value is live for runtime consumers...
+        assert s.database_pool_size == 7
+        # ...but pool sizing is never written to the settings blob.
+        blob = await _read_settings_blob(session)
+        assert "database_pool_size" not in blob
+        assert "database_max_overflow" not in blob
+        assert "database_pool_timeout" not in blob
+
+        # Even a stale blob that somehow carries a pool value must not win: env
+        # stays authoritative on the next initialize.
+        await session.exec(  # type: ignore
+            text("UPDATE settings SET data = :d WHERE id = 1").bindparams(
+                d=json.dumps({"database_pool_size": 99})
+            )
+        )
+        await session.commit()
+        again = await SettingsService.initialize(session)
+        assert again.database_pool_size == 7
+
+
+@pytest.mark.asyncio
+async def test_update_does_not_apply_env_only_fields_to_live_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB pool sizing is env-only: a settings update must neither persist it nor
+    mutate the live value. The engine pool is already built at boot from env, so
+    a UI/API update carrying a pool value must not make the live setting diverge
+    from the running pool.
+    """
+    monkeypatch.delenv("DATABASE_POOL_SIZE", raising=False)
+    monkeypatch.setattr(settings, "database_pool_size", 5)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        await SettingsService.initialize(session)
+        await SettingsService.update(
+            {"database_pool_size": 99, "name": "PoolTweaker"}, session
+        )
+
+        # A non-env-only field still updates normally...
+        assert settings.name == "PoolTweaker"
+        # ...but the env-only pool size stays at the boot value.
+        assert settings.database_pool_size == 5
+        # ...and it is never written to the settings blob.
+        blob = await _read_settings_blob(session)
+        assert "database_pool_size" not in blob
+
+
 @pytest.mark.parametrize(
     "field,bad_value",
     [


### PR DESCRIPTION
## Problem

Under load, admin/API endpoints start returning 500/502 and the logs fill with SQLAlchemy connection-pool exhaustion:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

often alongside:

```
This session is provisioning a new connection; concurrent operations are not permitted
```

Once it starts, background tasks (invoice watcher, dead-key prune, stale-reservation sweep) and the balances page all fail with the same `QueuePool limit ... reached` error, and only a container restart clears the wedged connections — until it recurs.

## Root cause

`fetch_all_balances()` created **one** `AsyncSession` and shared it across the tasks it ran with `asyncio.gather`:

```python
async with db.create_session() as session:
    tasks = [
        fetch_balance(session, mint_url, unit)   # each awaits a query on `session`
        for mint_url in mint_urls
        for unit in units
    ]
    balance_details = list(await asyncio.gather(*tasks))
```

`AsyncSession` is **not safe for concurrent use**. Overlapping queries on the shared session raise *"concurrent operations are not permitted"* and leave the underlying connection checked-out and wedged. Repeated over time, the `QueuePool` (5 + 10 overflow, 30s timeout) is drained and every DB path 500s.

## What this PR does

Two independent, separately-reviewable commits.

### 1. `fix:` stop AsyncSession pool exhaustion in balance reads

- **One up-front grouped read.** All outstanding user liabilities are read once, in a single short-lived session with a single `GROUP BY` query (`balances_by_mint_and_unit`), *before* the concurrent fan-out. The per-mint balance checks then run concurrently with **no DB session in scope**, so nothing shares a session across `gather`.
- **Graceful degradation.** If the liability read fails, the balances page no longer 500s. It still reports the known **wallet custody** and blanks only the unknowable per-user/owner split, tagging each mint with the error. The wallet total is reported truthfully; `owner` is reported as `0` so custody is never mis-reported as owner profit; and a specific per-mint failure message is preserved rather than being overwritten by the generic liability-read error.
- **Payout money-safety.** `periodic_payout` now reads each liability **fresh, immediately before the payout decision**, instead of from a single pre-loop snapshot. The per-mint round trip is slow (a `sleep(5)` plus mint I/O per iteration); a user top-up during the cycle would otherwise let a later mint/unit compute `available_balance = fresh_proofs − stale_liability` and **over-send funds owed to users**. (Related to the payout-safety concern in issue #611.)

### 2. `feat:` make the DB connection pool env-configurable

- Adds `DATABASE_POOL_SIZE` / `DATABASE_MAX_OVERFLOW` / `DATABASE_POOL_TIMEOUT`, consumed like every other typed env var through the pydantic `Settings` (constrained `Field`s; defaults **5 / 10 / 30** match SQLAlchemy's own baseline, so leaving them unset is behaviour-neutral).
- **Fail-loud on bad config.** An out-of-range or non-integer value fails validation and **refuses to boot** — the same behaviour a malformed `DATABASE_URL` already has — instead of silently starting up misconfigured.
- `create_db_engine` sizes the pool from these values and **logs the effective config at startup** (`Database pool configured: ...`) so it can be confirmed from the boot output during an incident. In-memory SQLite uses `StaticPool` (which rejects the pool kwargs) and is detected and built without them.
- **`pool_pre_ping` is intentionally not exposed.** The default backend is a local SQLite file with no network peer to drop idle connections, so it would add a `SELECT 1` per checkout for no benefit — and it detects *dead* connections, not the live-but-wedged ones behind this exhaustion.
- **Env-only, never DB-configured.** These knobs are infrastructure the node needs *before* it can open a DB session, so they can never be sourced from the DB (chicken-and-egg). A new `ENV_ONLY_FIELDS` set keeps them out of the persisted settings blob and stops a DB value from shadowing env in both `SettingsService.initialize` and `.update` — env stays authoritative.
- `.env.example` gains a documented **"Database tuning"** section (defaults, the exact `QueuePool` symptom to watch for, the boot log line, the fail-loud note, and the caveat that SQLite serialises writes so a bigger pool only helps concurrent readers).

## Testing

- `balances_by_mint_and_unit`: real-DB coverage for grouping/summing, mint+unit filtering, NULL-key exclusion, and empty inputs.
- `fetch_all_balances`: a session-concurrency guard asserting the liabilities are read in exactly one session with one query and never shared across the fan-out; graceful-degradation asserting custody is still reported while the user/owner split is blanked; and that a specific mint error survives a concurrent liability-read failure.
- `periodic_payout`: asserts the liability is read fresh once per `(mint, unit)`, after the inner sleep — not from a pre-loop snapshot.
- Pool config: defaults match the baseline; overrides flow through; in-memory SQLite skips the kwargs; pre-ping stays off; the effective config is logged; and non-integer / out-of-range / negative values are rejected at boot (`max_overflow=0` is allowed).
- Settings: the pool fields are never written to the blob and a stale/injected blob value never shadows env, on both `initialize` and `update`.

`make lint` clean (ruff + mypy). `make test-fast`: 1063 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
