### PR TITLE
fix(docker): exclude runtime state from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,39 +8,41 @@
 .todo
 
 # Local configuration and secrets
-.env
-.env.*
-routstr_secret.key
+**/.env
+**/.env.*
+**/routstr_secret.key
 
 # Python environments, caches, and build artifacts
-.venv
-__pycache__
-*.py[cod]
-.pytest_cache
-.mypy_cache
-.ruff_cache
-.coverage
-htmlcov
-*.egg-info
-build
-dist
+**/.venv
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/.coverage
+**/htmlcov
+**/*.egg-info
+**/build
+**/dist
 
 # Runtime state must never be baked into the image
 logs
 logs.*
-*.log
-.wallet
-.cashu
-*.db
-*.db-*
-*.sqlite3
-keys
-proof_backups
-relay-data
+**/*.log
+**/.wallet*
+**/.cashu
+**/*.db
+**/*.db-*
+**/*.sqlite3
+**/*.sqlite3-*
+**/keys
+**/proof_backups
+**/relay-data
 
-# The UI is built by its own service and mounted at runtime
-ui
+# The UI output is built by its own service and mounted at runtime
 ui_out
+ui/.next
+ui/out
 **/node_modules
 
 # Compose and local development files

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,51 @@
-.env
-.venv
+# Git and repository metadata
 .git
 .gitignore
 .dockerignore
-compose.yml
-compose.testing.yml
-.todo
 .github
 .vscode
 .DS_Store
+.todo
+
+# Local configuration and secrets
+.env
+.env.*
+routstr_secret.key
+
+# Python environments, caches, and build artifacts
+.venv
+__pycache__
+*.py[cod]
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+*.egg-info
+build
+dist
+
+# Runtime state must never be baked into the image
+logs
+logs.*
+*.log
+.wallet
+.cashu
+*.db
+*.db-*
+*.sqlite3
+keys
+proof_backups
+relay-data
+
+# The UI is built by its own service and mounted at runtime
+ui
+ui_out
 **/node_modules
-ui/.next
+
+# Compose and local development files
+compose.yml
+compose.testing.yml
+compose.override.yml
+plans
+.worktrees

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -12,27 +11,35 @@ def test_backend_docker_context_excludes_generated_and_runtime_state() -> None:
     }
 
     required_patterns = {
-        "__pycache__",
-        "*.py[cod]",
-        ".pytest_cache",
-        ".mypy_cache",
-        ".ruff_cache",
-        ".coverage",
-        "*.egg-info",
-        "build",
-        "dist",
+        "**/.env",
+        "**/.env.*",
+        "**/routstr_secret.key",
+        "**/.venv",
+        "**/__pycache__",
+        "**/*.py[cod]",
+        "**/.pytest_cache",
+        "**/.mypy_cache",
+        "**/.ruff_cache",
+        "**/.coverage",
+        "**/htmlcov",
+        "**/*.egg-info",
+        "**/build",
+        "**/dist",
         "logs",
         "logs.*",
-        ".wallet",
-        ".cashu",
-        "*.db",
-        "*.db-*",
-        "*.sqlite3",
-        "keys",
-        "proof_backups",
-        "relay-data",
-        "ui",
+        "**/*.log",
+        "**/.wallet*",
+        "**/.cashu",
+        "**/*.db",
+        "**/*.db-*",
+        "**/*.sqlite3",
+        "**/*.sqlite3-*",
+        "**/keys",
+        "**/proof_backups",
+        "**/relay-data",
         "ui_out",
+        "ui/.next",
+        "ui/out",
     }
 
     assert required_patterns <= patterns, (

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_backend_docker_context_excludes_generated_and_runtime_state() -> None:
+    patterns = {
+        line.strip()
+        for line in (REPO_ROOT / ".dockerignore").read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    required_patterns = {
+        "__pycache__",
+        "*.py[cod]",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".coverage",
+        "*.egg-info",
+        "build",
+        "dist",
+        "logs",
+        "logs.*",
+        ".wallet",
+        ".cashu",
+        "*.db",
+        "*.db-*",
+        "*.sqlite3",
+        "keys",
+        "proof_backups",
+        "relay-data",
+        "ui",
+        "ui_out",
+    }
+
+    assert required_patterns <= patterns, (
+        "The backend Docker context must exclude local build artifacts and "
+        f"runtime state; missing patterns: {sorted(required_patterns - patterns)}"
+    )


### PR DESCRIPTION
## Summary

- exclude local databases, wallet state, logs, caches, build artifacts, and secrets from the backend Docker context
- exclude the separately-built UI source and output from the backend image
- add a regression test for the required `.dockerignore` protections

## Root cause

The backend Dockerfile uses `COPY . .`, but `.dockerignore` only excluded a small set of paths. A long-running node therefore sent local runtime state into BuildKit, including `logs/`, `logs.docker/`, `.wallet/`, `keys.db*`, caches, and `ui_out/`.

On the reproduced node this produced a **716.09 MB** context. The reported failing build transferred **1.26 GB** before BuildKit ended with:

```text
rpc error: code = Canceled desc = grpc: the client connection is closing
```

The gRPC message is the transport-level failure; the repository defect is the unbounded context containing mutable runtime data.

## Verification

- Before: `docker compose build routstr` transferred **716.09 MB**
- After: `docker compose build routstr` transferred **3.63 MB**
- Reduction: **99.49%** / **197.3x smaller**
- Backend image built successfully
- Image smoke test confirmed application sources exist and runtime state/UI directories are absent
- Regression test passes

## Test plan

```bash
docker compose build --progress=plain routstr
python3 -c "import runpy; ns=runpy.run_path('tests/unit/test_docker_build_context.py'); ns['test_backend_docker_context_excludes_generated_and_runtime_state']()"
```
