### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+## SECURITY.md
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately to **team@routstr.com**.
+
+Do not open a public GitHub issue or disclose the vulnerability publicly until we have had a
+reasonable opportunity to investigate and coordinate a fix.
+
+Please include, where possible:
+
+- The affected Routstr package and version or commit
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+
+Do not include real Cashu tokens, seed phrases, private keys, or other secrets.
+
+We will acknowledge your report and coordinate remediation and disclosure with you.
+
+## Supported Versions
+
+Security fixes are provided for the latest released version.


### PR DESCRIPTION
Adds a security policy file (SECURITY.md) adapted from the Cashu/CoCo template for Routstr Core.

- Private vulnerability reports to **team@routstr.com**
- Includes guidance for what to include in a report
- Documents supported versions (latest released version)