### PR TITLE
fix: refresh keyset cache on unknown-keyset DLEQ failure instead of 500

### DIFF
--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -350,6 +350,66 @@ async def _load_and_resolve_token_proofs(
     return proofs
 
 
+# Message fragment of the AssertionError Cashu's ``verify_proofs_dleq`` raises
+# when a proof's keyset is missing from the wallet's local keyset cache.
+_UNKNOWN_KEYSET_DLEQ_MARKER = "can not verify DLEQ"
+
+
+async def _verify_proofs_dleq_with_refresh(
+    wallet: Wallet, token_obj: Token, proofs: list[Proof]
+) -> None:
+    """Verify DLEQ proofs, refreshing the local keyset cache once on a miss.
+
+    Cashu's ``verify_proofs_dleq`` asserts every proof's keyset is present in
+    ``wallet.keysets``, which is hydrated from the wallet's local keyset
+    database. When the mint has rotated keysets since the cache was populated,
+    the assertion fires even though the token is perfectly valid — previously
+    surfacing as an unclassified AssertionError and an HTTP 500 on every
+    redemption attempt until the cache was rebuilt by hand.
+
+    On that specific assertion, refetch the mint's keysets (including inactive
+    ones, which older tokens reference) and retry the verification once. A
+    keyset that is still unknown after a fresh fetch means the mint does not
+    serve it at all, so the token cannot be verified here — raise the same
+    ValueError taxonomy as the short-keyset-ID resolver above (400, not 500).
+    """
+    try:
+        wallet.verify_proofs_dleq(proofs)
+        return
+    except AssertionError as error:
+        if _UNKNOWN_KEYSET_DLEQ_MARKER not in str(error):
+            raise
+        logger.warning(
+            "DLEQ verification hit unknown keyset; refreshing keyset cache",
+            extra={
+                "event": "cashu_dleq_unknown_keyset_refresh",
+                "source_mint": token_obj.mint,
+                "source_unit": token_obj.unit,
+                "error": str(error),
+            },
+        )
+
+    try:
+        await run_mint_operation(
+            lambda: wallet.load_mint_keysets(force_old_keysets=True),
+            op_name="redeem_refresh_keysets",
+            mint_url=token_obj.mint,
+        )
+    except Exception as error:
+        if is_mint_connection_error(error) or is_mint_rate_limited(error):
+            raise
+        raise MintConnectionError("Cashu mint keysets are unavailable") from error
+
+    try:
+        wallet.verify_proofs_dleq(proofs)
+    except AssertionError as error:
+        if _UNKNOWN_KEYSET_DLEQ_MARKER not in str(error):
+            raise
+        raise ValueError(
+            "Cashu token references an unknown or ambiguous keyset"
+        ) from error
+
+
 async def _redeem_same_mint(
     wallet: Wallet, token_obj: Token
 ) -> tuple[int, str, str]:  # amount, unit, mint_url
@@ -367,6 +427,7 @@ async def _redeem_same_mint(
             token_obj,
             op_name="redeem_load_mint",
         )
+        await _verify_proofs_dleq_with_refresh(wallet, token_obj, proofs)
     except Exception as error:
         if is_mint_connection_error(error):
             logger.warning(
@@ -387,7 +448,6 @@ async def _redeem_same_mint(
             ) from error
         raise
 
-    wallet.verify_proofs_dleq(proofs)
     input_fees = wallet.get_fees_for_proofs(proofs)
     try:
         await run_mint_operation(

--- a/tests/unit/test_dleq_keyset_refresh.py
+++ b/tests/unit/test_dleq_keyset_refresh.py
@@ -1,0 +1,109 @@
+"""Unit tests for keyset-cache refresh on unknown-keyset DLEQ failures."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from routstr import wallet as wallet_module
+from routstr.wallet import _verify_proofs_dleq_with_refresh
+
+UNKNOWN_KEYSET_ERROR = AssertionError(
+    "Keyset 01fc0ec0e59cd6fa not known, can not verify DLEQ."
+)
+
+TOKEN = SimpleNamespace(mint="https://mint.example.com", unit="sat", amount=100)
+PROOFS: list[Any] = []
+
+
+class FakeWallet:
+    """Wallet stub whose DLEQ verification fails until keysets are refreshed."""
+
+    def __init__(
+        self,
+        fail_first: bool = False,
+        fail_always: bool = False,
+        error: Exception = UNKNOWN_KEYSET_ERROR,
+    ) -> None:
+        self.fail_first = fail_first
+        self.fail_always = fail_always
+        self.error = error
+        self.verify_calls = 0
+        self.refresh_calls: list[bool] = []
+
+    def verify_proofs_dleq(self, proofs: list[Any]) -> None:
+        self.verify_calls += 1
+        if self.fail_always or (self.fail_first and not self.refresh_calls):
+            raise self.error
+
+    async def load_mint_keysets(self, force_old_keysets: bool = False) -> None:
+        self.refresh_calls.append(force_old_keysets)
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_mint_operation(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_mint_operation(operation: Any, **_kwargs: Any) -> Any:
+        return await operation()
+
+    monkeypatch.setattr(wallet_module, "run_mint_operation", fake_run_mint_operation)
+
+
+async def test_no_refresh_when_verification_succeeds() -> None:
+    wallet = FakeWallet()
+    await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]
+    assert wallet.verify_calls == 1
+    assert wallet.refresh_calls == []
+
+
+async def test_unknown_keyset_refreshes_and_retries_once() -> None:
+    wallet = FakeWallet(fail_first=True)
+    await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]
+    assert wallet.verify_calls == 2
+    # Refresh must include inactive keysets, which older tokens reference.
+    assert wallet.refresh_calls == [True]
+
+
+async def test_keyset_still_unknown_after_refresh_raises_value_error() -> None:
+    wallet = FakeWallet(fail_always=True)
+    with pytest.raises(ValueError, match="unknown or ambiguous keyset"):
+        await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]
+    assert wallet.verify_calls == 2
+    assert wallet.refresh_calls == [True]
+
+
+async def test_invalid_dleq_proof_propagates_without_refresh() -> None:
+    # Cashu raises a different message for an actually-invalid DLEQ proof;
+    # that must not be masked by a keyset refresh.
+    wallet = FakeWallet(fail_always=True, error=AssertionError("DLEQ proof invalid."))
+    with pytest.raises(AssertionError, match="DLEQ proof invalid"):
+        await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]
+    assert wallet.verify_calls == 1
+    assert wallet.refresh_calls == []
+
+
+async def test_refresh_connection_failure_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    wallet = FakeWallet(fail_first=True)
+
+    async def failing_run_mint_operation(operation: Any, **_kwargs: Any) -> Any:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(wallet_module, "run_mint_operation", failing_run_mint_operation)
+    with pytest.raises(httpx.ConnectError):
+        await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]
+
+
+async def test_refresh_unclassified_failure_maps_to_mint_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wallet = FakeWallet(fail_first=True)
+
+    async def failing_run_mint_operation(operation: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("keyset db corrupted")
+
+    monkeypatch.setattr(wallet_module, "run_mint_operation", failing_run_mint_operation)
+    with pytest.raises(wallet_module.MintConnectionError):
+        await _verify_proofs_dleq_with_refresh(wallet, TOKEN, PROOFS)  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

Between 08-11 and 08-13, redemptions against minibits failed ~13k times with:

```
Keyset 01fc0ec0e59cd6fa not known, can not verify DLEQ.
```

This is an `AssertionError` from Cashu's `verify_proofs_dleq`: the proof's keyset was missing from the wallet's *local* keyset cache (mint had rotated keysets since the cache was populated). `classify_redemption_error` has no branch for it, so every attempt surfaced as an unclassified HTTP 500 — for tokens that were perfectly valid — until the cache was rebuilt by hand. Combined with polling clients, this also generated sustained retry load against the mint.

## Solution

New `_verify_proofs_dleq_with_refresh` helper in `routstr/wallet.py`, used by `_redeem_same_mint`:

1. Verify DLEQ as before; on the specific "can not verify DLEQ" assertion, refetch mint keysets with `force_old_keysets=True` (older tokens reference inactive keysets) and retry verification **once**.
2. Keyset still unknown after a fresh fetch → the mint does not serve it → raise the existing `ValueError("Cashu token references an unknown or ambiguous keyset")` taxonomy (400), matching the short-keyset-ID resolver — never a 500.
3. A genuinely invalid DLEQ proof (`DLEQ proof invalid.`) propagates untouched — the refresh must not mask forged proofs.
4. Refresh transport failures reuse the standard mint-connection classification; the verify call moved inside `_redeem_same_mint`'s pre-swap-dispatch try block, so they get the same `SourceMintConnectionError` → 503 handling as keyset-load failures.