### PR TITLE
feat: identify client app in request and error logs

### DIFF
--- a/routstr/core/logging.py
+++ b/routstr/core/logging.py
@@ -185,11 +185,9 @@ class RequestIdFilter(logging.Filter):
 class ClientAppFilter(logging.Filter):
     """Filter to add the requesting client app to all log records.
 
-    The client app (the app or agent that made the request) is resolved by the
-    logging middleware from the OpenRouter-convention identity headers
-    (``X-Title``/``HTTP-Referer``, falling back to ``User-Agent``) and stored
-    in a context variable, so every log line emitted while handling a request
-    carries it — including error messages raised deep in the wallet/mint code.
+    The middleware resolves it from the OpenRouter-convention identity headers
+    (X-Title, then Referer, then User-Agent) into a context variable, so even
+    errors raised deep in the wallet/mint code carry it.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/routstr/core/logging.py
+++ b/routstr/core/logging.py
@@ -183,26 +183,15 @@ class RequestIdFilter(logging.Filter):
 
 
 class ClientAppFilter(logging.Filter):
-    """Filter to add the requesting client app to all log records.
-
-    The middleware resolves it from the OpenRouter-convention identity headers
-    (X-Title, then Referer, then User-Agent) into a context variable, so even
-    errors raised deep in the wallet/mint code carry it.
-    """
+    """Filter to add the requesting client app to all log records."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Add the client app to the log record unless set explicitly."""
-        if hasattr(record, "client_app"):
-            return True
-        try:
-            # Import here to avoid circular imports
-            from .middleware import UNKNOWN_CLIENT_APP, client_app_context
+        """Add the client app to the log record if available."""
+        # Import here to avoid circular imports
+        from .middleware import UNKNOWN_CLIENT_APP, client_app_context
 
-            client_app = client_app_context.get(None)
-            record.client_app = client_app if client_app else UNKNOWN_CLIENT_APP
-        except ImportError:
-            # If middleware isn't available yet, just use default
-            record.client_app = "unknown"
+        client_app = client_app_context.get(None)
+        record.client_app = client_app if client_app else UNKNOWN_CLIENT_APP
         return True
 
 

--- a/routstr/core/logging.py
+++ b/routstr/core/logging.py
@@ -182,6 +182,32 @@ class RequestIdFilter(logging.Filter):
         return True
 
 
+class ClientAppFilter(logging.Filter):
+    """Filter to add the requesting client app to all log records.
+
+    The client app (the app or agent that made the request) is resolved by the
+    logging middleware from the OpenRouter-convention identity headers
+    (``X-Title``/``HTTP-Referer``, falling back to ``User-Agent``) and stored
+    in a context variable, so every log line emitted while handling a request
+    carries it — including error messages raised deep in the wallet/mint code.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add the client app to the log record unless set explicitly."""
+        if hasattr(record, "client_app"):
+            return True
+        try:
+            # Import here to avoid circular imports
+            from .middleware import UNKNOWN_CLIENT_APP, client_app_context
+
+            client_app = client_app_context.get(None)
+            record.client_app = client_app if client_app else UNKNOWN_CLIENT_APP
+        except ImportError:
+            # If middleware isn't available yet, just use default
+            record.client_app = "unknown"
+        return True
+
+
 # Standard ``LogRecord`` attributes that are never user-supplied ``extra``
 # fields; skipped when redacting structured extras (``msg``/``message`` are
 # handled separately above).
@@ -323,7 +349,7 @@ def setup_logging() -> None:
             "rich_tracebacks": True,
             "markup": True,
             "console": _console,
-            "filters": ["request_id_filter", "security_filter"],
+            "filters": ["request_id_filter", "client_app_filter", "security_filter"],
         }
     else:
         console_handler = {
@@ -331,7 +357,7 @@ def setup_logging() -> None:
             "level": log_level,
             "formatter": "plain",
             "stream": "ext://sys.stdout",
-            "filters": ["request_id_filter", "security_filter"],
+            "filters": ["request_id_filter", "client_app_filter", "security_filter"],
         }
 
     LOGGING_CONFIG = {
@@ -340,7 +366,7 @@ def setup_logging() -> None:
         "formatters": {
             "json": {
                 "()": jsonlogger.JsonFormatter,
-                "format": "%(asctime)s %(name)s %(levelname)s %(message)s %(pathname)s %(lineno)d %(version)s %(request_id)s",
+                "format": "%(asctime)s %(name)s %(levelname)s %(message)s %(pathname)s %(lineno)d %(version)s %(request_id)s %(client_app)s",
                 "datefmt": "%Y-%m-%d %H:%M:%S",
             },
             "plain": {
@@ -351,6 +377,7 @@ def setup_logging() -> None:
         "filters": {
             "version_filter": {"()": VersionFilter},
             "request_id_filter": {"()": RequestIdFilter},
+            "client_app_filter": {"()": ClientAppFilter},
             "security_filter": {"()": SecurityFilter},
         },
         "handlers": {
@@ -364,7 +391,12 @@ def setup_logging() -> None:
                 "interval": 1,  # Every 1 day
                 "backupCount": 30,  # Keep 30 days of logs
                 "atTime": None,  # Rotate at midnight (00:00)
-                "filters": ["version_filter", "request_id_filter", "security_filter"],
+                "filters": [
+                    "version_filter",
+                    "request_id_filter",
+                    "client_app_filter",
+                    "security_filter",
+                ],
             },
         },
         "loggers": {

--- a/routstr/core/middleware.py
+++ b/routstr/core/middleware.py
@@ -14,26 +14,26 @@ logger = get_logger(__name__)
 # Context variable to store request ID across async context
 request_id_context: ContextVar[str | None] = ContextVar("request_id")
 
-# Context variable holding the client app behind the current request, so log
-# lines emitted while handling it (wallet/mint errors included) can say who
-# triggered it.
+# Context variable to store the client app across async context
 client_app_context: ContextVar[str | None] = ContextVar("client_app")
 
 UNKNOWN_CLIENT_APP = "unknown"
 
-# OpenRouter-convention identity headers, in priority order: X-Title carries
-# the app name, HTTP-Referer its URL; User-Agent covers SDKs and scripts that
-# set neither.
-_CLIENT_APP_HEADERS: tuple[str, ...] = ("x-title", "referer", "user-agent")
+# Identity headers in priority order. X-Title and HTTP-Referer are the
+# OpenRouter convention; User-Agent covers SDKs and scripts that set neither.
+_CLIENT_APP_HEADERS: tuple[str, ...] = (
+    "x-title",
+    "http-referer",
+    "referer",
+    "user-agent",
+)
 
-# Headers are attacker-controlled free text: cap the length so one request
-# can't bloat every log line, strip control characters so a crafted value
-# can't forge log records.
+# Header values are attacker-controlled: cap the length so one request can't
+# bloat every log line.
 _CLIENT_APP_MAX_LENGTH = 120
 
 
 def client_app_from_headers(headers: Headers) -> str:
-    """Resolve the requesting app from identity headers, or "unknown"."""
     for header in _CLIENT_APP_HEADERS:
         raw = headers.get(header)
         if raw is None:
@@ -101,9 +101,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         # Set request ID in context for logging
         token = request_id_context.set(request_id)
 
-        client_app = client_app_from_headers(request.headers)
-        request.state.client_app = client_app
-        client_app_token = client_app_context.set(client_app)
+        client_app_token = client_app_context.set(
+            client_app_from_headers(request.headers)
+        )
 
         path = request.url.path
         should_log = _should_log(request.method, path)
@@ -118,7 +118,6 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     "request_id": request_id,
                     "method": request.method,
                     "path": path,
-                    "client_app": client_app,
                     "query_params": dict(request.query_params),
                 },
             )
@@ -135,7 +134,6 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                         "request_id": request_id,
                         "method": request.method,
                         "path": path,
-                        "client_app": client_app,
                         "status_code": response.status_code,
                         "duration_ms": round(duration * 1000, 2),
                     },
@@ -154,7 +152,6 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     "request_id": request_id,
                     "method": request.method,
                     "path": path,
-                    "client_app": client_app,
                     "duration_ms": round(duration * 1000, 2),
                     "error": str(e),
                     "error_type": type(e).__name__,
@@ -172,6 +169,5 @@ __all__ = [
     "LoggingMiddleware",
     "UNKNOWN_CLIENT_APP",
     "client_app_context",
-    "client_app_from_headers",
     "request_id_context",
 ]

--- a/routstr/core/middleware.py
+++ b/routstr/core/middleware.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 from typing import Callable
 
 from fastapi import Request, Response
+from starlette.datastructures import Headers
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .logging import get_logger
@@ -12,6 +13,39 @@ logger = get_logger(__name__)
 
 # Context variable to store request ID across async context
 request_id_context: ContextVar[str | None] = ContextVar("request_id")
+
+# Context variable holding the client app that made the current request, so
+# every log line emitted while handling it (including deep wallet/mint errors)
+# can say who triggered it. "unknown" when the client sent no identity headers.
+client_app_context: ContextVar[str | None] = ContextVar("client_app")
+
+UNKNOWN_CLIENT_APP = "unknown"
+
+# Client identity headers, in priority order. Follows the OpenRouter
+# convention: apps identify themselves with ``X-Title`` (human-readable app
+# name) and/or ``HTTP-Referer`` (app URL); ``User-Agent`` is the fallback for
+# SDKs and scripts that set neither.
+_CLIENT_APP_HEADERS: tuple[str, ...] = ("x-title", "referer", "user-agent")
+
+# Header values are attacker-controlled free text; cap the length so a single
+# request can't bloat every log line, and strip control characters so a crafted
+# header can't inject fake log records.
+_CLIENT_APP_MAX_LENGTH = 120
+
+
+def client_app_from_headers(headers: Headers) -> str:
+    """Resolve the client app identity from request headers.
+
+    Priority: ``X-Title`` > ``HTTP-Referer`` > ``User-Agent`` > "unknown".
+    """
+    for header in _CLIENT_APP_HEADERS:
+        raw = headers.get(header)
+        if raw is None:
+            continue
+        cleaned = "".join(ch for ch in raw if ch.isprintable()).strip()
+        if cleaned:
+            return cleaned[:_CLIENT_APP_MAX_LENGTH]
+    return UNKNOWN_CLIENT_APP
 
 
 # Methods that are never logged: HEAD requests are health probes from
@@ -71,6 +105,10 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         # Set request ID in context for logging
         token = request_id_context.set(request_id)
 
+        client_app = client_app_from_headers(request.headers)
+        request.state.client_app = client_app
+        client_app_token = client_app_context.set(client_app)
+
         path = request.url.path
         should_log = _should_log(request.method, path)
 
@@ -84,6 +122,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     "request_id": request_id,
                     "method": request.method,
                     "path": path,
+                    "client_app": client_app,
                     "query_params": dict(request.query_params),
                 },
             )
@@ -100,6 +139,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                         "request_id": request_id,
                         "method": request.method,
                         "path": path,
+                        "client_app": client_app,
                         "status_code": response.status_code,
                         "duration_ms": round(duration * 1000, 2),
                     },
@@ -118,6 +158,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     "request_id": request_id,
                     "method": request.method,
                     "path": path,
+                    "client_app": client_app,
                     "duration_ms": round(duration * 1000, 2),
                     "error": str(e),
                     "error_type": type(e).__name__,
@@ -128,6 +169,13 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         finally:
             # Reset context
             request_id_context.reset(token)
+            client_app_context.reset(client_app_token)
 
 
-__all__ = ["LoggingMiddleware", "request_id_context"]
+__all__ = [
+    "LoggingMiddleware",
+    "UNKNOWN_CLIENT_APP",
+    "client_app_context",
+    "client_app_from_headers",
+    "request_id_context",
+]

--- a/routstr/core/middleware.py
+++ b/routstr/core/middleware.py
@@ -14,30 +14,26 @@ logger = get_logger(__name__)
 # Context variable to store request ID across async context
 request_id_context: ContextVar[str | None] = ContextVar("request_id")
 
-# Context variable holding the client app that made the current request, so
-# every log line emitted while handling it (including deep wallet/mint errors)
-# can say who triggered it. "unknown" when the client sent no identity headers.
+# Context variable holding the client app behind the current request, so log
+# lines emitted while handling it (wallet/mint errors included) can say who
+# triggered it.
 client_app_context: ContextVar[str | None] = ContextVar("client_app")
 
 UNKNOWN_CLIENT_APP = "unknown"
 
-# Client identity headers, in priority order. Follows the OpenRouter
-# convention: apps identify themselves with ``X-Title`` (human-readable app
-# name) and/or ``HTTP-Referer`` (app URL); ``User-Agent`` is the fallback for
-# SDKs and scripts that set neither.
+# OpenRouter-convention identity headers, in priority order: X-Title carries
+# the app name, HTTP-Referer its URL; User-Agent covers SDKs and scripts that
+# set neither.
 _CLIENT_APP_HEADERS: tuple[str, ...] = ("x-title", "referer", "user-agent")
 
-# Header values are attacker-controlled free text; cap the length so a single
-# request can't bloat every log line, and strip control characters so a crafted
-# header can't inject fake log records.
+# Headers are attacker-controlled free text: cap the length so one request
+# can't bloat every log line, strip control characters so a crafted value
+# can't forge log records.
 _CLIENT_APP_MAX_LENGTH = 120
 
 
 def client_app_from_headers(headers: Headers) -> str:
-    """Resolve the client app identity from request headers.
-
-    Priority: ``X-Title`` > ``HTTP-Referer`` > ``User-Agent`` > "unknown".
-    """
+    """Resolve the requesting app from identity headers, or "unknown"."""
     for header in _CLIENT_APP_HEADERS:
         raw = headers.get(header)
         if raw is None:

--- a/tests/unit/test_client_app_logging.py
+++ b/tests/unit/test_client_app_logging.py
@@ -1,19 +1,18 @@
-"""Unit tests for client-app identification in request logging."""
+"""Tests for client-app identification in request logging."""
 
 import logging
 
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
 from starlette.datastructures import Headers
 
 from routstr.core.logging import ClientAppFilter
 from routstr.core.middleware import (
     UNKNOWN_CLIENT_APP,
+    LoggingMiddleware,
     client_app_context,
     client_app_from_headers,
 )
-
-
-def _headers(**kwargs: str) -> Headers:
-    return Headers({k.replace("_", "-"): v for k, v in kwargs.items()})
 
 
 def _record() -> logging.LogRecord:
@@ -28,68 +27,123 @@ def _record() -> logging.LogRecord:
     )
 
 
-class TestClientAppFromHeaders:
-    def test_x_title_wins_over_all(self) -> None:
-        headers = _headers(
-            x_title="Goose",
-            referer="https://myapp.example.com",
-            user_agent="python-httpx/0.27",
-        )
-        assert client_app_from_headers(headers) == "Goose"
-
-    def test_referer_used_when_no_x_title(self) -> None:
-        headers = _headers(
-            referer="https://myapp.example.com", user_agent="python-httpx/0.27"
-        )
-        assert client_app_from_headers(headers) == "https://myapp.example.com"
-
-    def test_user_agent_is_last_fallback(self) -> None:
-        headers = _headers(user_agent="python-httpx/0.27")
-        assert client_app_from_headers(headers) == "python-httpx/0.27"
-
-    def test_unknown_when_no_identity_headers(self) -> None:
-        assert client_app_from_headers(Headers({})) == UNKNOWN_CLIENT_APP
-        assert UNKNOWN_CLIENT_APP == "unknown"
-
-    def test_blank_header_falls_through_to_next(self) -> None:
-        headers = _headers(x_title="   ", user_agent="curl/8.4.0")
-        assert client_app_from_headers(headers) == "curl/8.4.0"
-
-    def test_all_blank_resolves_to_unknown(self) -> None:
-        headers = _headers(x_title="   ", user_agent="\t")
-        assert client_app_from_headers(headers) == UNKNOWN_CLIENT_APP
-
-    def test_value_is_truncated(self) -> None:
-        headers = _headers(x_title="a" * 500)
-        assert client_app_from_headers(headers) == "a" * 120
-
-    def test_control_characters_are_stripped(self) -> None:
-        # A crafted header must not be able to inject fake log records.
-        headers = _headers(user_agent="evil-app\x1b[0m fake INFO line")
-        assert client_app_from_headers(headers) == "evil-app[0m fake INFO line"
+# ---------------------------------------------------------------------------
+# client_app_from_headers
+# ---------------------------------------------------------------------------
 
 
-class TestClientAppFilter:
-    def test_uses_context_variable(self) -> None:
-        token = client_app_context.set("Goose")
-        try:
-            record = _record()
-            assert ClientAppFilter().filter(record) is True
-            assert record.client_app == "Goose"  # type: ignore[attr-defined]
-        finally:
-            client_app_context.reset(token)
+def test_x_title_takes_priority() -> None:
+    """X-Title wins over Referer and User-Agent."""
+    headers = Headers(
+        {
+            "x-title": "Goose",
+            "referer": "https://myapp.example.com",
+            "user-agent": "python-httpx/0.27",
+        }
+    )
+    assert client_app_from_headers(headers) == "Goose"
 
-    def test_defaults_to_unknown_outside_request_context(self) -> None:
+
+def test_referer_used_when_no_x_title() -> None:
+    headers = Headers(
+        {"referer": "https://myapp.example.com", "user-agent": "python-httpx/0.27"}
+    )
+    assert client_app_from_headers(headers) == "https://myapp.example.com"
+
+
+def test_user_agent_is_last_fallback() -> None:
+    assert (
+        client_app_from_headers(Headers({"user-agent": "curl/8.4.0"})) == "curl/8.4.0"
+    )
+
+
+def test_unknown_when_no_identity_headers() -> None:
+    assert client_app_from_headers(Headers({})) == UNKNOWN_CLIENT_APP
+
+
+def test_blank_header_falls_through_to_next() -> None:
+    """A whitespace-only X-Title must not shadow a usable User-Agent."""
+    headers = Headers({"x-title": "   ", "user-agent": "curl/8.4.0"})
+    assert client_app_from_headers(headers) == "curl/8.4.0"
+
+
+def test_all_blank_resolves_to_unknown() -> None:
+    headers = Headers({"x-title": "   ", "user-agent": "\t"})
+    assert client_app_from_headers(headers) == UNKNOWN_CLIENT_APP
+
+
+def test_value_is_truncated_to_120_chars() -> None:
+    assert client_app_from_headers(Headers({"x-title": "a" * 500})) == "a" * 120
+
+
+def test_control_characters_are_stripped() -> None:
+    """A crafted header must not be able to forge log records."""
+    headers = Headers({"user-agent": "evil-app\x1b[0m fake INFO line"})
+    assert client_app_from_headers(headers) == "evil-app[0m fake INFO line"
+
+
+# ---------------------------------------------------------------------------
+# ClientAppFilter
+# ---------------------------------------------------------------------------
+
+
+def test_filter_reads_context_variable() -> None:
+    token = client_app_context.set("Goose")
+    try:
         record = _record()
         assert ClientAppFilter().filter(record) is True
-        assert record.client_app == UNKNOWN_CLIENT_APP  # type: ignore[attr-defined]
+        assert record.client_app == "Goose"  # type: ignore[attr-defined]
+    finally:
+        client_app_context.reset(token)
 
-    def test_explicit_extra_is_not_overwritten(self) -> None:
-        token = client_app_context.set("context-app")
-        try:
-            record = _record()
-            record.client_app = "explicit-app"  # type: ignore[attr-defined]
-            assert ClientAppFilter().filter(record) is True
-            assert record.client_app == "explicit-app"  # type: ignore[attr-defined]
-        finally:
-            client_app_context.reset(token)
+
+def test_filter_defaults_to_unknown_outside_request_context() -> None:
+    record = _record()
+    assert ClientAppFilter().filter(record) is True
+    assert record.client_app == UNKNOWN_CLIENT_APP  # type: ignore[attr-defined]
+
+
+def test_filter_keeps_explicit_extra() -> None:
+    """extra={"client_app": ...} on a log call wins over the context value."""
+    token = client_app_context.set("context-app")
+    try:
+        record = _record()
+        record.client_app = "explicit-app"  # type: ignore[attr-defined]
+        assert ClientAppFilter().filter(record) is True
+        assert record.client_app == "explicit-app"  # type: ignore[attr-defined]
+    finally:
+        client_app_context.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# LoggingMiddleware integration
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_exposes_client_app_on_request_state() -> None:
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict:
+        return {"client_app": request.state.client_app}
+
+    app.add_middleware(LoggingMiddleware)
+    client = TestClient(app)
+
+    response = client.get("/whoami", headers={"X-Title": "Goose"})
+    assert response.json() == {"client_app": "Goose"}
+
+
+def test_middleware_reports_unknown_without_identity_headers() -> None:
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict:
+        return {"client_app": request.state.client_app}
+
+    app.add_middleware(LoggingMiddleware)
+    # TestClient sets its own User-Agent; blank it out to simulate a bare client.
+    client = TestClient(app, headers={"user-agent": ""})
+
+    response = client.get("/whoami")
+    assert response.json() == {"client_app": UNKNOWN_CLIENT_APP}

--- a/tests/unit/test_client_app_logging.py
+++ b/tests/unit/test_client_app_logging.py
@@ -1,0 +1,95 @@
+"""Unit tests for client-app identification in request logging."""
+
+import logging
+
+from starlette.datastructures import Headers
+
+from routstr.core.logging import ClientAppFilter
+from routstr.core.middleware import (
+    UNKNOWN_CLIENT_APP,
+    client_app_context,
+    client_app_from_headers,
+)
+
+
+def _headers(**kwargs: str) -> Headers:
+    return Headers({k.replace("_", "-"): v for k, v in kwargs.items()})
+
+
+def _record() -> logging.LogRecord:
+    return logging.LogRecord(
+        name="routstr.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="test",
+        args=None,
+        exc_info=None,
+    )
+
+
+class TestClientAppFromHeaders:
+    def test_x_title_wins_over_all(self) -> None:
+        headers = _headers(
+            x_title="Goose",
+            referer="https://myapp.example.com",
+            user_agent="python-httpx/0.27",
+        )
+        assert client_app_from_headers(headers) == "Goose"
+
+    def test_referer_used_when_no_x_title(self) -> None:
+        headers = _headers(
+            referer="https://myapp.example.com", user_agent="python-httpx/0.27"
+        )
+        assert client_app_from_headers(headers) == "https://myapp.example.com"
+
+    def test_user_agent_is_last_fallback(self) -> None:
+        headers = _headers(user_agent="python-httpx/0.27")
+        assert client_app_from_headers(headers) == "python-httpx/0.27"
+
+    def test_unknown_when_no_identity_headers(self) -> None:
+        assert client_app_from_headers(Headers({})) == UNKNOWN_CLIENT_APP
+        assert UNKNOWN_CLIENT_APP == "unknown"
+
+    def test_blank_header_falls_through_to_next(self) -> None:
+        headers = _headers(x_title="   ", user_agent="curl/8.4.0")
+        assert client_app_from_headers(headers) == "curl/8.4.0"
+
+    def test_all_blank_resolves_to_unknown(self) -> None:
+        headers = _headers(x_title="   ", user_agent="\t")
+        assert client_app_from_headers(headers) == UNKNOWN_CLIENT_APP
+
+    def test_value_is_truncated(self) -> None:
+        headers = _headers(x_title="a" * 500)
+        assert client_app_from_headers(headers) == "a" * 120
+
+    def test_control_characters_are_stripped(self) -> None:
+        # A crafted header must not be able to inject fake log records.
+        headers = _headers(user_agent="evil-app\x1b[0m fake INFO line")
+        assert client_app_from_headers(headers) == "evil-app[0m fake INFO line"
+
+
+class TestClientAppFilter:
+    def test_uses_context_variable(self) -> None:
+        token = client_app_context.set("Goose")
+        try:
+            record = _record()
+            assert ClientAppFilter().filter(record) is True
+            assert record.client_app == "Goose"  # type: ignore[attr-defined]
+        finally:
+            client_app_context.reset(token)
+
+    def test_defaults_to_unknown_outside_request_context(self) -> None:
+        record = _record()
+        assert ClientAppFilter().filter(record) is True
+        assert record.client_app == UNKNOWN_CLIENT_APP  # type: ignore[attr-defined]
+
+    def test_explicit_extra_is_not_overwritten(self) -> None:
+        token = client_app_context.set("context-app")
+        try:
+            record = _record()
+            record.client_app = "explicit-app"  # type: ignore[attr-defined]
+            assert ClientAppFilter().filter(record) is True
+            assert record.client_app == "explicit-app"  # type: ignore[attr-defined]
+        finally:
+            client_app_context.reset(token)

--- a/tests/unit/test_client_app_logging.py
+++ b/tests/unit/test_client_app_logging.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from fastapi import FastAPI, Request
+import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.datastructures import Headers
 
@@ -27,49 +28,42 @@ def _record() -> logging.LogRecord:
     )
 
 
-# ---------------------------------------------------------------------------
-# client_app_from_headers
-# ---------------------------------------------------------------------------
-
-
-def test_x_title_takes_priority() -> None:
-    """X-Title wins over Referer and User-Agent."""
-    headers = Headers(
-        {
-            "x-title": "Goose",
-            "referer": "https://myapp.example.com",
-            "user-agent": "python-httpx/0.27",
-        }
-    )
-    assert client_app_from_headers(headers) == "Goose"
-
-
-def test_referer_used_when_no_x_title() -> None:
-    headers = Headers(
-        {"referer": "https://myapp.example.com", "user-agent": "python-httpx/0.27"}
-    )
-    assert client_app_from_headers(headers) == "https://myapp.example.com"
-
-
-def test_user_agent_is_last_fallback() -> None:
-    assert (
-        client_app_from_headers(Headers({"user-agent": "curl/8.4.0"})) == "curl/8.4.0"
-    )
-
-
-def test_unknown_when_no_identity_headers() -> None:
-    assert client_app_from_headers(Headers({})) == UNKNOWN_CLIENT_APP
-
-
-def test_blank_header_falls_through_to_next() -> None:
-    """A whitespace-only X-Title must not shadow a usable User-Agent."""
-    headers = Headers({"x-title": "   ", "user-agent": "curl/8.4.0"})
-    assert client_app_from_headers(headers) == "curl/8.4.0"
-
-
-def test_all_blank_resolves_to_unknown() -> None:
-    headers = Headers({"x-title": "   ", "user-agent": "\t"})
-    assert client_app_from_headers(headers) == UNKNOWN_CLIENT_APP
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        (
+            {
+                "x-title": "Goose",
+                "http-referer": "https://myapp.example.com",
+                "user-agent": "python-httpx/0.27",
+            },
+            "Goose",
+        ),
+        (
+            {"http-referer": "https://myapp.example.com", "user-agent": "curl/8.4.0"},
+            "https://myapp.example.com",
+        ),
+        (
+            {"referer": "https://myapp.example.com", "user-agent": "curl/8.4.0"},
+            "https://myapp.example.com",
+        ),
+        ({"user-agent": "curl/8.4.0"}, "curl/8.4.0"),
+        ({}, UNKNOWN_CLIENT_APP),
+        ({"x-title": "   ", "user-agent": "curl/8.4.0"}, "curl/8.4.0"),
+        ({"x-title": "   ", "user-agent": "\t"}, UNKNOWN_CLIENT_APP),
+    ],
+    ids=[
+        "x-title-wins",
+        "http-referer",
+        "referer",
+        "user-agent-fallback",
+        "no-identity-headers",
+        "blank-falls-through",
+        "all-blank",
+    ],
+)
+def test_client_app_from_headers(headers: dict[str, str], expected: str) -> None:
+    assert client_app_from_headers(Headers(headers)) == expected
 
 
 def test_value_is_truncated_to_120_chars() -> None:
@@ -80,11 +74,6 @@ def test_control_characters_are_stripped() -> None:
     """A crafted header must not be able to forge log records."""
     headers = Headers({"user-agent": "evil-app\x1b[0m fake INFO line"})
     assert client_app_from_headers(headers) == "evil-app[0m fake INFO line"
-
-
-# ---------------------------------------------------------------------------
-# ClientAppFilter
-# ---------------------------------------------------------------------------
 
 
 def test_filter_reads_context_variable() -> None:
@@ -103,47 +92,24 @@ def test_filter_defaults_to_unknown_outside_request_context() -> None:
     assert record.client_app == UNKNOWN_CLIENT_APP  # type: ignore[attr-defined]
 
 
-def test_filter_keeps_explicit_extra() -> None:
-    """extra={"client_app": ...} on a log call wins over the context value."""
-    token = client_app_context.set("context-app")
+def test_handler_logs_carry_client_app(caplog: pytest.LogCaptureFixture) -> None:
+    """A log line emitted inside a handler still names the app that triggered it."""
+    app = FastAPI()
+    handler_logger = logging.getLogger("routstr.test.handler")
+
+    @app.get("/whoami")
+    async def whoami() -> dict[str, bool]:
+        handler_logger.warning("something went wrong")
+        return {"ok": True}
+
+    app.add_middleware(LoggingMiddleware)
+
+    caplog.handler.addFilter(ClientAppFilter())
+    handler_logger.addHandler(caplog.handler)
     try:
-        record = _record()
-        record.client_app = "explicit-app"  # type: ignore[attr-defined]
-        assert ClientAppFilter().filter(record) is True
-        assert record.client_app == "explicit-app"  # type: ignore[attr-defined]
+        TestClient(app).get("/whoami", headers={"X-Title": "Goose"})
     finally:
-        client_app_context.reset(token)
+        handler_logger.removeHandler(caplog.handler)
 
-
-# ---------------------------------------------------------------------------
-# LoggingMiddleware integration
-# ---------------------------------------------------------------------------
-
-
-def test_middleware_exposes_client_app_on_request_state() -> None:
-    app = FastAPI()
-
-    @app.get("/whoami")
-    async def whoami(request: Request) -> dict:
-        return {"client_app": request.state.client_app}
-
-    app.add_middleware(LoggingMiddleware)
-    client = TestClient(app)
-
-    response = client.get("/whoami", headers={"X-Title": "Goose"})
-    assert response.json() == {"client_app": "Goose"}
-
-
-def test_middleware_reports_unknown_without_identity_headers() -> None:
-    app = FastAPI()
-
-    @app.get("/whoami")
-    async def whoami(request: Request) -> dict:
-        return {"client_app": request.state.client_app}
-
-    app.add_middleware(LoggingMiddleware)
-    # TestClient sets its own User-Agent; blank it out to simulate a bare client.
-    client = TestClient(app, headers={"user-agent": ""})
-
-    response = client.get("/whoami")
-    assert response.json() == {"client_app": UNKNOWN_CLIENT_APP}
+    record = next(r for r in caplog.records if r.name == "routstr.test.handler")
+    assert record.client_app == "Goose"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

When a misbehaving client hammers the API (see the retry-amplification analysis behind #672/#673 and issue #674), the logs cannot say *what* is doing it — there is no record of the app or agent behind a request. Attribution had to be reverse-engineered from request-gap histograms.

## Solution

Follow the OpenRouter convention for app attribution (the app or agent that made the request):

- `X-Title` — human-readable app name (highest priority)
- `HTTP-Referer` — app URL
- `User-Agent` — fallback for SDKs/scripts that set neither
- `unknown` — when none are present or all are blank