### PR TITLE
fix: recognize 'Unknown quote' mint error as definitively unpaid

### DIFF
--- a/routstr/lightning.py
+++ b/routstr/lightning.py
@@ -601,8 +601,20 @@ async def check_invoice_payment(
 
 
 def _is_quote_not_found(error: BaseException) -> bool:
-    """Check if the error indicates the mint no longer has this quote."""
+    """Check if the error indicates the mint no longer has this quote.
+
+    Recognised variants:
+    - ``Mint Error: quote not found (Code: 0)`` (legacy wording) — treated as
+      definitive only with the exact ``0`` code, because some mints reuse the
+      ``quote not found`` wording for ambiguous states.
+    - ``Mint Error: Unknown quote (Code: 50000)`` — reported by some mint
+      implementations when the quote id was never issued or was dropped. The
+      wording itself is definitive (the mint has no record of the quote), and
+      the numeric code varies (seen as ``50000``), so no code check is applied.
+    """
     message = str(error)
+    if re.search(r"\bunknown\s+quote\b", message, re.IGNORECASE):
+        return True
     return bool(
         re.search(r"\bquote\s+not\s+found\b", message, re.IGNORECASE)
         and re.search(r"\bcode\s*:?\s*0\b", message, re.IGNORECASE)

--- a/routstr/lightning.py
+++ b/routstr/lightning.py
@@ -603,14 +603,9 @@ async def check_invoice_payment(
 def _is_quote_not_found(error: BaseException) -> bool:
     """Check if the error indicates the mint no longer has this quote.
 
-    Recognised variants:
-    - ``Mint Error: quote not found (Code: 0)`` (legacy wording) — treated as
-      definitive only with the exact ``0`` code, because some mints reuse the
-      ``quote not found`` wording for ambiguous states.
-    - ``Mint Error: Unknown quote (Code: 50000)`` — reported by some mint
-      implementations when the quote id was never issued or was dropped. The
-      wording itself is definitive (the mint has no record of the quote), and
-      the numeric code varies (seen as ``50000``), so no code check is applied.
+    ``Unknown quote`` is definitive on wording alone and its numeric code varies
+    between mints. ``quote not found`` needs ``Code: 0`` because some mints reuse
+    that wording for ambiguous states.
     """
     message = str(error)
     if re.search(r"\bunknown\s+quote\b", message, re.IGNORECASE):

--- a/tests/unit/test_lightning_settlement.py
+++ b/tests/unit/test_lightning_settlement.py
@@ -218,6 +218,58 @@ async def test_quote_not_found_case_insensitive() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unknown_quote_is_definitively_unpaid() -> None:
+    """Some mints report a dropped quote as 'Unknown quote (Code: 50000)'."""
+    _invoice_settlement_locks.clear()
+    invoice = _invoice(status="pending", expires_at=0)
+    session = AsyncMock()
+    wallet = Mock(
+        get_mint_quote=AsyncMock(
+            side_effect=Exception("Mint Error: Unknown quote (Code: 50000)")
+        )
+    )
+
+    with (
+        patch("routstr.lightning.get_wallet", AsyncMock(return_value=wallet)),
+        patch("routstr.lightning._reload_invoice_view", AsyncMock()),
+    ):
+        result = await check_invoice_payment(invoice, session)  # type: ignore[arg-type]
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # legacy wording must still require the exact code 0
+        "Mint Error: quote not found (Code: 10000)",
+        "Mint Error: quote not found (Code: 50000)",
+        # not actually referring to a mint quote id
+        "Mint Error: unknown request",
+        "connection error: quote endpoint unreachable",
+    ],
+)
+def test_unknown_quote_only_matches_real_quote_missing_errors(message: str) -> None:
+    from routstr.lightning import _is_quote_not_found
+
+    assert not _is_quote_not_found(Exception(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Mint Error: Unknown quote (Code: 50000)",
+        "MINT ERROR: UNKNOWN QUOTE (CODE 50000)",
+        "Mint Error: unknown quote (Code: 11000)",
+    ],
+)
+def test_unknown_quote_wording_is_recognized(message: str) -> None:
+    from routstr.lightning import _is_quote_not_found
+
+    assert _is_quote_not_found(Exception(message))
+
+
+@pytest.mark.asyncio
 async def test_credited_invoice_is_not_minted() -> None:
     _invoice_settlement_locks.clear()
     invoice = _invoice(status="paid")

--- a/tests/unit/test_lightning_settlement.py
+++ b/tests/unit/test_lightning_settlement.py
@@ -14,6 +14,7 @@ from routstr.lightning import (
     InvoiceRecoverRequest,
     _invoice_settlement_locks,
     _is_outputs_already_signed,
+    _is_quote_not_found,
     _mint_invoice_quote,
     check_invoice_payment,
     get_invoice_status,
@@ -219,7 +220,6 @@ async def test_quote_not_found_case_insensitive() -> None:
 
 @pytest.mark.asyncio
 async def test_unknown_quote_is_definitively_unpaid() -> None:
-    """Some mints report a dropped quote as 'Unknown quote (Code: 50000)'."""
     _invoice_settlement_locks.clear()
     invoice = _invoice(status="pending", expires_at=0)
     session = AsyncMock()
@@ -241,17 +241,14 @@ async def test_unknown_quote_is_definitively_unpaid() -> None:
 @pytest.mark.parametrize(
     "message",
     [
-        # legacy wording must still require the exact code 0
+        # legacy wording still requires the exact code 0
         "Mint Error: quote not found (Code: 10000)",
         "Mint Error: quote not found (Code: 50000)",
-        # not actually referring to a mint quote id
         "Mint Error: unknown request",
         "connection error: quote endpoint unreachable",
     ],
 )
 def test_unknown_quote_only_matches_real_quote_missing_errors(message: str) -> None:
-    from routstr.lightning import _is_quote_not_found
-
     assert not _is_quote_not_found(Exception(message))
 
 
@@ -264,8 +261,6 @@ def test_unknown_quote_only_matches_real_quote_missing_errors(message: str) -> N
     ],
 )
 def test_unknown_quote_wording_is_recognized(message: str) -> None:
-    from routstr.lightning import _is_quote_not_found
-
     assert _is_quote_not_found(Exception(message))
 
 


### PR DESCRIPTION
## Problem

After a node restart, the invoice watcher began emitting floods of a previously-unseen error, repeated in batches every ~10s:

```
ERROR routstr.lightning Failed to check invoice payment: Mint Error: Unknown quote (Code: 50000)
```

**Root cause** is a classification gap in `_is_quote_not_found()` (`routstr/lightning.py`). The watcher polls invoices stuck in `pending`/`settlement_pending` every cycle and calls `check_invoice_payment()`, which asks the mint for the quote. When the mint no longer has the quote, the handler is supposed to recognise that as *definitively unpaid* → mark the invoice expired → drop it out of the poll loop.

But the classifier only matched **`quote not found` with an exact code of `0`**:

```python
re.search(r"\bquote\s+not\s+found\b", msg) and re.search(r"\bcode\s*:?\s*0\b", msg)
```

This mint reports a dropped/unknown quote as **`Unknown quote (Code: 50000)`** — different wording *and* different code. Neither regex matches, so the error is re-raised to the outer catch-all, logged as an ERROR, and `check_invoice_payment` returns `False`. The invoice therefore **never gets expired** and is re-polled — and re-errored — every watcher cycle, indefinitely.