### PR TITLE
Coordinate mint interactions across workers

### DIFF
--- a/routstr/auth.py
+++ b/routstr/auth.py
@@ -31,7 +31,10 @@ from .payment.cost_calculation import (
     calculate_cost,
 )
 from .redemption_cache import (
+    MAX_TRANSIENT_TTL_SECONDS,
     TERMINAL_REDEMPTION_CODES,
+    TRANSIENT_REDEMPTION_CODES,
+    TRANSIENT_TTL_SECONDS,
     CachedRedemptionFailure,
     redemption_negative_cache,
 )
@@ -188,19 +191,30 @@ def _cached_failure_to_http_exception(
     )
 
 
-def _maybe_cache_terminal_redemption_failure(hashed_key: str, error: Exception) -> None:
-    """Record a redemption failure in the negative cache if it can never succeed.
-
-    Transient classifications (mint unreachable, rate-limited) are never
-    cached — only codes in TERMINAL_REDEMPTION_CODES, which are permanent
-    properties of the token itself.
-    """
+def _maybe_cache_redemption_failure(hashed_key: str, error: Exception) -> None:
+    """Cache sanitized redemption failures for their configured lifetime."""
     classified = classify_redemption_error(error)
     if classified is None:
         return
     error_type, status_code, message, code = classified
-    if code not in TERMINAL_REDEMPTION_CODES:
+    ttl_seconds: float | None = None
+    if code in TRANSIENT_REDEMPTION_CODES:
+        ttl_seconds = TRANSIENT_TTL_SECONDS
+        current: BaseException | None = error
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            retry_after = getattr(current, "retry_after_seconds", None)
+            if isinstance(retry_after, (int, float)):
+                ttl_seconds = min(
+                    MAX_TRANSIENT_TTL_SECONDS,
+                    max(1.0, float(retry_after)),
+                )
+                break
+            current = current.__cause__ or current.__context__
+    elif code not in TERMINAL_REDEMPTION_CODES:
         return
+
     redemption_negative_cache.put(
         hashed_key,
         CachedRedemptionFailure(
@@ -209,10 +223,15 @@ def _maybe_cache_terminal_redemption_failure(hashed_key: str, error: Exception) 
             message=message,
             code=code,
         ),
+        ttl_seconds=ttl_seconds,
     )
     logger.info(
-        "Cached terminal redemption failure; further attempts rejected locally",
-        extra={"key_hash": hashed_key[:8] + "...", "code": code},
+        "Cached redemption failure; further attempts rejected locally",
+        extra={
+            "key_hash": hashed_key[:8] + "...",
+            "code": code,
+            "ttl_seconds": ttl_seconds,
+        },
     )
 
 
@@ -431,7 +450,7 @@ async def _validate_bearer_key_locked(
 
             if cached_failure := redemption_negative_cache.get(hashed_key):
                 logger.info(
-                    "Rejecting known-dead Cashu token from negative cache",
+                    "Rejecting Cashu token with a cached redemption failure",
                     extra={
                         "key_hash": hashed_key[:8] + "...",
                         "code": cached_failure.code,
@@ -506,6 +525,7 @@ async def _validate_bearer_key_locked(
             )
             try:
                 msats = await credit_balance(bearer_key, new_key, session)
+                redemption_negative_cache.discard(hashed_key)
                 logger.debug(
                     "AUTH: credit_balance returned successfully", extra={"msats": msats}
                 )
@@ -518,7 +538,7 @@ async def _validate_bearer_key_locked(
                     },
                 )
                 await session.rollback()
-                _maybe_cache_terminal_redemption_failure(hashed_key, credit_error)
+                _maybe_cache_redemption_failure(hashed_key, credit_error)
                 raise redemption_error_to_http_exception(credit_error) from credit_error
 
             if msats <= 0:

--- a/routstr/core/admin.py
+++ b/routstr/core/admin.py
@@ -1770,6 +1770,74 @@ async def get_log_dates_api(request: Request) -> dict[str, object]:
     return {"dates": dates}
 
 
+_ROUTSTR_RELEASE_ERRORS = {
+    "no_active_reservation": "No pending Routstr auto top-up to release",
+    "stale_state": (
+        "The reservation changed since it was reviewed; reload and check again"
+    ),
+    "reservation_changed": (
+        "The reservation changed while the release was being applied; reload and check again"
+    ),
+}
+
+
+class ReleaseRoutstrAutoTopupRequest(BaseModel):
+    confirmed_token_was_not_used: bool
+    state_token: str | None = None
+
+
+async def _require_routstr_provider(provider_id: int) -> UpstreamProviderRow:
+    async with create_session() as session:
+        provider = await session.get(UpstreamProviderRow, provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    if provider.provider_type != "routstr":
+        raise HTTPException(status_code=400, detail="Provider is not Routstr")
+    return provider
+
+
+@admin_router.get(
+    "/api/upstream-providers/{provider_id}/routstr-auto-topup",
+    dependencies=[Depends(require_admin_api)],
+)
+async def get_routstr_auto_topup_api(provider_id: int) -> dict[str, object]:
+    await _require_routstr_provider(provider_id)
+    from ..upstream.auto_topup import get_routstr_auto_topup_state
+
+    return {"ok": True, **await get_routstr_auto_topup_state(provider_id)}
+
+
+@admin_router.post(
+    "/api/upstream-providers/{provider_id}/routstr-auto-topup/release",
+    dependencies=[Depends(require_admin_api)],
+)
+async def release_routstr_auto_topup_api(
+    provider_id: int, payload: ReleaseRoutstrAutoTopupRequest
+) -> dict[str, object]:
+    await _require_routstr_provider(provider_id)
+    if not payload.confirmed_token_was_not_used:
+        raise HTTPException(
+            status_code=400,
+            detail="Confirm the Cashu token was not used before releasing",
+        )
+
+    from ..upstream.auto_topup import release_routstr_auto_topup_state
+
+    outcome = await release_routstr_auto_topup_state(
+        provider_id, state_token=payload.state_token
+    )
+    if not outcome.released:
+        raise HTTPException(
+            status_code=409, detail=_ROUTSTR_RELEASE_ERRORS[outcome.reason]
+        )
+
+    logger.warning(
+        "Admin released Routstr auto top-up after manual reconciliation",
+        extra={"provider_id": provider_id, "state_token": payload.state_token},
+    )
+    return {"ok": True, "released": True}
+
+
 _PPQ_RELEASE_ERRORS = {
     "no_active_claim": "No active PPQ claim to release",
     "stale_state": ("The claim changed since it was reviewed; reload and check again"),

--- a/routstr/lightning.py
+++ b/routstr/lightning.py
@@ -39,6 +39,7 @@ logger = get_logger(__name__)
 
 lightning_router = APIRouter(prefix="/lightning")
 
+
 # Avoid duplicate work within one process. Cross-process settlement is fenced
 # by claiming a paid quote before minting and by the final conditional update.
 @dataclass
@@ -285,9 +286,7 @@ async def create_invoice(
             # A key's liabilities are attributed to a single refund mint. Keep
             # top-up collateral on that same mint so balances and payouts cannot
             # misclassify funds held by another mint as owner profit.
-            allowed_mints = [
-                topup_api_key.refund_mint_url or settings.primary_mint
-            ]
+            allowed_mints = [topup_api_key.refund_mint_url or settings.primary_mint]
         bolt11, payment_hash, mint_url = await generate_lightning_invoice(
             request.amount_sats, description, allowed_mints=allowed_mints
         )
@@ -471,7 +470,7 @@ async def check_invoice_payment(
             await session.commit()
 
             mint_url = settlement.mint_url or settings.primary_mint
-            wallet = await get_wallet(mint_url, "sat")
+            wallet = await get_wallet(mint_url, "sat", load=False)
             try:
                 mint_status = await run_mint_operation(
                     lambda: wallet.get_mint_quote(settlement.payment_hash),
@@ -532,6 +531,7 @@ async def check_invoice_payment(
 
             # Quote-linked proof verification makes an ambiguous mint response
             # retryable without crediting unrelated wallet balance growth.
+            wallet = await get_wallet(mint_url, "sat")
             await _mint_invoice_quote(wallet, settlement)
             minted = True
 
@@ -553,9 +553,7 @@ async def check_invoice_payment(
                     "invoice_id": settlement.id,
                     "amount_sats": settlement.amount_sats,
                     "purpose": settlement.purpose,
-                    "api_key_hash": api_key_hash[:8] + "..."
-                    if api_key_hash
-                    else None,
+                    "api_key_hash": api_key_hash[:8] + "..." if api_key_hash else None,
                 },
             )
             return False
@@ -577,9 +575,7 @@ async def check_invoice_payment(
                         )
                         await state_session.commit()
                     if pending.rowcount == 1:
-                        _publish_invoice_value(
-                            invoice, "status", "settlement_pending"
-                        )
+                        _publish_invoice_value(invoice, "status", "settlement_pending")
                 except Exception as state_error:
                     logger.critical(
                         "Paid invoice reconciliation state could not be persisted",

--- a/routstr/mint.py
+++ b/routstr/mint.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import socket
 import time
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
+from pathlib import Path
 from typing import Any, AsyncGenerator, Awaitable, Callable
 
 import httpx
 
+from . import node_coordination
 from .core.logging import get_logger
 from .core.settings import settings
 
@@ -28,6 +31,17 @@ MINT_TRANSPORT_COOLDOWN_SECONDS = 30.0
 _MINT_RATE_LIMIT_BASE_COOLDOWN_SECONDS = 60.0
 _MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS = 7 * 60 * 60
 
+
+def _read_boot_id() -> str | None:
+    try:
+        value = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+# Monotonic clocks are shared by processes on one boot but reset on reboot.
+_NODE_BOOT_ID = _read_boot_id()
 _fail_fast_depth: ContextVar[int] = ContextVar("mint_fail_fast_depth", default=0)
 
 
@@ -75,7 +89,7 @@ async def fail_fast_mint_operations() -> AsyncGenerator[None, None]:
 
 
 class MintRateGuard:
-    """Limit concurrency and remember per-mint cooldown/probe state."""
+    """Apply one node-wide concurrency and cooldown policy per mint."""
 
     _guards: dict[str, "MintRateGuard"] = {}
 
@@ -84,15 +98,11 @@ class MintRateGuard:
         concurrency = settings.mint_max_concurrency
         guard = cls._guards.get(mint_url)
         if guard is None or guard._max_concurrency != concurrency:
-            previous = guard
             guard = cls(mint_url, concurrency)
-            if previous is not None:
-                # Concurrency changed at runtime: keep the live cooldown/backoff
-                # state so an active 429 cooldown is not silently discarded.
-                guard._cooldown_until = previous._cooldown_until
-                guard._cooldown_reason = previous._cooldown_reason
-                guard._consecutive_rate_limits = previous._consecutive_rate_limits
-                guard._needs_probe = previous._needs_probe
+            with node_coordination.blocking_lock(guard._state_lock_path):
+                state = guard._read_shared_state()
+                if state is not None:
+                    guard._write_local_state(*state[:4])
             cls._guards[mint_url] = guard
         return guard
 
@@ -107,37 +117,169 @@ class MintRateGuard:
         self._consecutive_rate_limits = 0
         self._needs_probe = False
         self._probe_lock = asyncio.Lock()
+        self._key = node_coordination.state_key(mint_url)
+
+    @property
+    def _directory(self) -> Path:
+        return node_coordination.NODE_STATE_DIR / "mints" / self._key
+
+    @property
+    def _state_path(self) -> Path:
+        return self._directory / "state.json"
+
+    @property
+    def _state_lock_path(self) -> Path:
+        return self._directory / "state.lock"
+
+    @property
+    def _probe_lock_path(self) -> Path:
+        return self._directory / "probe.lock"
+
+    def _read_shared_state(
+        self,
+    ) -> tuple[float, str | None, int, bool, int] | None:
+        value = node_coordination.read_json(self._state_path)
+        version = value.get("version") if value is not None else None
+        if value is None or version not in (1, 2, 3):
+            return None
+        try:
+            consecutive = int(value["consecutive_rate_limits"])
+            needs_probe = value["needs_probe"]
+            generation = int(value.get("generation", 0))
+            reason = value.get("reason")
+            same_boot = (
+                version == 3
+                and _NODE_BOOT_ID is not None
+                and value.get("boot_id") == _NODE_BOOT_ID
+            )
+            if same_boot:
+                cooldown_until = float(value["monotonic_until"])
+                now = time.monotonic()
+            else:
+                wall_until = float(value["cooldown_until"])
+                wall_now = time.time()
+                if (
+                    not math.isfinite(wall_until)
+                    or wall_until < 0
+                    or wall_until
+                    > wall_now + _MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS + 60
+                ):
+                    return None
+                cooldown_until = time.monotonic() + max(0.0, wall_until - wall_now)
+                now = time.monotonic()
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+        if (
+            not math.isfinite(cooldown_until)
+            or cooldown_until < 0
+            or cooldown_until > now + _MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS + 60
+            or not 0 <= consecutive <= 1024
+            or not 0 <= generation <= 2**63 - 1
+            or not isinstance(needs_probe, bool)
+            or (reason is not None and not isinstance(reason, str))
+        ):
+            return None
+        return cooldown_until, reason, consecutive, needs_probe, generation
+
+    def _write_shared_state(
+        self,
+        cooldown_until: float,
+        reason: str | None,
+        consecutive: int,
+        needs_probe: bool,
+        generation: int,
+    ) -> None:
+        remaining = max(0.0, cooldown_until - time.monotonic())
+        node_coordination.write_json(
+            self._state_path,
+            {
+                "version": 3,
+                "boot_id": _NODE_BOOT_ID,
+                "monotonic_until": cooldown_until,
+                "cooldown_until": time.time() + remaining,
+                "reason": reason,
+                "consecutive_rate_limits": consecutive,
+                "needs_probe": needs_probe,
+                "generation": generation,
+            },
+        )
+        self._cooldown_until = cooldown_until
+        self._cooldown_reason = reason
+        self._consecutive_rate_limits = consecutive
+        self._needs_probe = needs_probe
+
+    def _sync_shared_state(self) -> None:
+        state = self._read_shared_state()
+        if state is None:
+            return
+        self._write_local_state(*state[:4])
+
+    def _write_local_state(
+        self,
+        cooldown_until: float,
+        reason: str | None,
+        consecutive: int,
+        needs_probe: bool,
+    ) -> None:
+        self._cooldown_until = cooldown_until
+        self._cooldown_reason = reason
+        self._consecutive_rate_limits = consecutive
+        self._needs_probe = needs_probe
 
     def apply_cooldown(self, delay: float, *, reason: str | None = None) -> None:
-        deadline = time.monotonic() + max(0.0, delay)
-        if deadline >= self._cooldown_until:
-            self._cooldown_until = deadline
-            if reason is not None:
-                self._cooldown_reason = reason
-        elif self._cooldown_reason is None and reason is not None:
-            self._cooldown_reason = reason
-        self._needs_probe = True
+        delay = max(0.0, delay)
+        with node_coordination.blocking_lock(self._state_lock_path):
+            state = self._read_shared_state()
+            current_until, current_reason, consecutive, _, generation = state or (
+                0.0,
+                None,
+                self._consecutive_rate_limits,
+                False,
+                0,
+            )
+            deadline = time.monotonic() + delay
+            if deadline >= current_until:
+                current_until = deadline
+                if reason is not None:
+                    current_reason = reason
+            elif current_reason is None and reason is not None:
+                current_reason = reason
+            self._write_shared_state(
+                current_until, current_reason, consecutive, True, generation + 1
+            )
 
     def apply_rate_limit_cooldown(self, retry_after: float | None = None) -> float:
-        remaining = self.cooldown_remaining()
-        if remaining > 0 and self._cooldown_reason == "rate_limited":
+        with node_coordination.blocking_lock(self._state_lock_path):
+            state = self._read_shared_state()
+            current_until, reason, consecutive, _, generation = state or (
+                0.0,
+                None,
+                0,
+                False,
+                0,
+            )
+            remaining = max(0.0, current_until - time.monotonic())
             minimum = min(
                 _MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS,
                 max(_MINT_RATE_LIMIT_BASE_COOLDOWN_SECONDS, retry_after or 0.0),
             )
-            if minimum > remaining:
-                self.apply_cooldown(minimum, reason="rate_limited")
-                return minimum
-            return remaining
-
-        self._consecutive_rate_limits += 1
-        base = max(_MINT_RATE_LIMIT_BASE_COOLDOWN_SECONDS, retry_after or 0.0)
-        multiplier = 2 ** min(self._consecutive_rate_limits - 1, 10)
-        delay = min(_MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS, base * multiplier)
-        self.apply_cooldown(delay, reason="rate_limited")
-        return delay
+            if remaining > 0 and reason == "rate_limited":
+                delay = max(remaining, minimum)
+            else:
+                consecutive += 1
+                multiplier = 2 ** min(consecutive - 1, 10)
+                delay = min(_MINT_RATE_LIMIT_MAX_COOLDOWN_SECONDS, minimum * multiplier)
+            self._write_shared_state(
+                time.monotonic() + delay,
+                "rate_limited",
+                consecutive,
+                True,
+                generation + 1,
+            )
+            return delay
 
     def cooldown_remaining(self) -> float:
+        self._sync_shared_state()
         return max(0.0, self._cooldown_until - time.monotonic())
 
     def cooldown_reason(self) -> str | None:
@@ -151,8 +293,13 @@ class MintRateGuard:
     async def _wait_for_cooldown(self) -> None:
         while True:
             self._raise_if_wait_forbidden()
+            shared_state = self._read_shared_state()
+            if shared_state is not None:
+                self._write_local_state(*shared_state[:4])
+            wait = max(0.0, self._cooldown_until - time.monotonic())
             deadline = self._cooldown_until
-            wait = max(0.0, deadline - time.monotonic())
+            shared_deadline = shared_state[0] if shared_state is not None else None
+            generation = shared_state[4] if shared_state is not None else None
             if wait <= 0:
                 return
             logger.debug(
@@ -160,72 +307,157 @@ class MintRateGuard:
                 extra={"mint_url": self._mint_url, "wait_seconds": round(wait, 2)},
             )
             await asyncio.sleep(wait)
+            if shared_deadline is not None and generation is not None:
+                with node_coordination.blocking_lock(self._state_lock_path):
+                    current = self._read_shared_state()
+                    if (
+                        current is not None
+                        and current[4] == generation
+                        and current[0] <= time.monotonic()
+                    ):
+                        self._write_shared_state(
+                            0.0, current[1], current[2], True, generation + 1
+                        )
+            self._sync_shared_state()
             if self._cooldown_until <= deadline:
                 return
 
+    @asynccontextmanager
+    async def _node_slot(self) -> AsyncGenerator[None, None]:
+        if self._max_concurrency <= 0:
+            yield
+            return
+        fd: int | None = None
+        try:
+            while fd is None:
+                for slot in range(self._max_concurrency):
+                    fd = node_coordination.try_lock(
+                        self._directory / f"slot-{slot}.lock"
+                    )
+                    if fd is not None:
+                        break
+                if fd is None:
+                    await asyncio.sleep(0.05)
+            yield
+        finally:
+            if fd is not None:
+                node_coordination.unlock(fd)
+
+    async def _acquire_probe_lock(self) -> int:
+        while True:
+            fd = node_coordination.try_lock(self._probe_lock_path)
+            if fd is not None:
+                return fd
+            if _fail_fast_depth.get():
+                raise MintCooldownError(self._mint_url, self.cooldown_remaining())
+            await asyncio.sleep(0.05)
+
+    def _clear_shared_state(self, expected_generation: int) -> bool:
+        with node_coordination.blocking_lock(self._state_lock_path):
+            state = self._read_shared_state()
+            if state is None:
+                if expected_generation != 0:
+                    return False
+                self._write_shared_state(0.0, None, 0, False, 1)
+                return True
+            if state[4] != expected_generation:
+                self._write_local_state(*state[:4])
+                return False
+            self._write_shared_state(0.0, None, 0, False, expected_generation + 1)
+            return True
+
     async def _run_probe(self, factory: Callable[[], Awaitable[Any]]) -> Any:
         await self._wait_for_cooldown()
-        logger.info(
-            "Mint cooldown ended; sending one probe request",
-            extra={"event": "mint_cooldown_probe_started", "mint_url": self._mint_url},
-        )
+        if self._read_shared_state() is None:
+            self._cooldown_until = 0.0
+            self._needs_probe = True
+        fd: int | None = await self._acquire_probe_lock()
         try:
-            result = await factory()
-        except Exception as error:
-            if is_mint_rate_limited(error):
-                retry_after = None
-                if isinstance(error, httpx.HTTPStatusError):
-                    retry_after = parse_retry_after(error.response.headers)
-                self.apply_rate_limit_cooldown(retry_after)
-            else:
-                self.apply_cooldown(1.0)
-            logger.warning(
-                "Mint cooldown probe failed",
+            self._sync_shared_state()
+            if self.cooldown_remaining() > 0:
+                assert fd is not None
+                node_coordination.unlock(fd)
+                fd = None
+                await self._wait_for_cooldown()
+                return await self._run_probe(factory)
+            if not self._needs_probe:
+                assert fd is not None
+                node_coordination.unlock(fd)
+                fd = None
+                return await self.run(factory)
+            state = self._read_shared_state()
+            probe_generation = state[4] if state is not None else 0
+            logger.info(
+                "Mint cooldown ended; sending one probe request",
                 extra={
-                    "event": "mint_cooldown_probe_failed",
+                    "event": "mint_cooldown_probe_started",
                     "mint_url": self._mint_url,
-                    "error": str(error),
-                    "error_type": type(error).__name__,
-                    "cooldown_seconds": round(self.cooldown_remaining(), 2),
-                    "consecutive_rate_limits": self._consecutive_rate_limits,
                 },
             )
-            raise
-
-        self._needs_probe = False
-        self._cooldown_until = 0.0
-        self._cooldown_reason = None
-        self._consecutive_rate_limits = 0
-        logger.info(
-            "Mint cooldown probe succeeded; restoring normal concurrency",
-            extra={
-                "event": "mint_cooldown_probe_succeeded",
-                "mint_url": self._mint_url,
-            },
-        )
-        return result
+            try:
+                async with self._node_slot():
+                    result = await factory()
+            except Exception as error:
+                if is_mint_rate_limited(error):
+                    retry_after = None
+                    if isinstance(error, httpx.HTTPStatusError):
+                        retry_after = parse_retry_after(error.response.headers)
+                    self.apply_rate_limit_cooldown(retry_after)
+                else:
+                    self.apply_cooldown(1.0)
+                logger.warning(
+                    "Mint cooldown probe failed",
+                    extra={
+                        "event": "mint_cooldown_probe_failed",
+                        "mint_url": self._mint_url,
+                        "error": str(error),
+                        "error_type": type(error).__name__,
+                        "cooldown_seconds": round(self.cooldown_remaining(), 2),
+                        "consecutive_rate_limits": self._consecutive_rate_limits,
+                    },
+                )
+                raise
+            state_cleared = self._clear_shared_state(probe_generation)
+            logger.info(
+                "Mint cooldown probe succeeded",
+                extra={
+                    "event": "mint_cooldown_probe_succeeded",
+                    "mint_url": self._mint_url,
+                    "state_cleared": state_cleared,
+                },
+            )
+            return result
+        finally:
+            if fd is not None:
+                node_coordination.unlock(fd)
 
     async def run(self, factory: Callable[[], Awaitable[Any]]) -> Any:
         while True:
             self._raise_if_wait_forbidden()
+            self._sync_shared_state()
             if self._needs_probe or self.cooldown_remaining() > 0:
                 if _fail_fast_depth.get() and self._probe_lock.locked():
                     raise MintCooldownError(self._mint_url, self.cooldown_remaining())
                 async with self._probe_lock:
                     self._raise_if_wait_forbidden()
-                    if self.cooldown_remaining() > 0:
-                        self._needs_probe = True
-                    if self._needs_probe:
+                    self._sync_shared_state()
+                    if self._needs_probe or self.cooldown_remaining() > 0:
                         return await self._run_probe(factory)
                 continue
 
             if self._semaphore is None:
-                return await factory()
+                async with self._node_slot():
+                    self._sync_shared_state()
+                    if self._needs_probe:
+                        continue
+                    return await factory()
             async with self._semaphore:
-                self._raise_if_wait_forbidden()
-                if self._needs_probe:
-                    continue
-                return await factory()
+                async with self._node_slot():
+                    self._raise_if_wait_forbidden()
+                    self._sync_shared_state()
+                    if self._needs_probe:
+                        continue
+                    return await factory()
 
 
 def mint_cooldown_remaining(mint_url: str) -> float:

--- a/routstr/node_coordination.py
+++ b/routstr/node_coordination.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import Any, AsyncGenerator, Generator
+
+NODE_STATE_DIR = Path(".wallet") / ".routstr-node"
+_MAX_STATE_BYTES = 16 * 1024
+_MAX_INTEGER_DIGITS = 128
+
+
+def _parse_int(value: str) -> int:
+    if len(value.removeprefix("-")) > _MAX_INTEGER_DIGITS:
+        raise ValueError("node coordination integer is too large")
+    return int(value)
+
+
+def _read_boot_id() -> str | None:
+    try:
+        value = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+NODE_BOOT_ID = _read_boot_id()
+
+
+def state_key(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    fd: int | None = None
+    try:
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        fd = os.open(path, flags)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return None
+        with os.fdopen(fd, "rb") as file:
+            fd = None
+            payload = file.read(_MAX_STATE_BYTES + 1)
+        if len(payload) > _MAX_STATE_BYTES:
+            return None
+        value = json.loads(payload.decode(), parse_int=_parse_int)
+    except (OSError, UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    finally:
+        if fd is not None:
+            os.close(fd)
+    return value if isinstance(value, dict) else None
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    if len(payload) > _MAX_STATE_BYTES:
+        raise ValueError("node coordination state is too large")
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as file:
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def try_lock(path: Path) -> int | None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(fd)
+        return None
+    return fd
+
+
+def unlock(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def blocking_lock(path: Path) -> Generator[None, None, None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        unlock(fd)
+
+
+@asynccontextmanager
+async def exclusive_lock(path: Path) -> AsyncGenerator[None, None]:
+    fd: int | None = None
+    try:
+        while fd is None:
+            fd = try_lock(path)
+            if fd is None:
+                await asyncio.sleep(0.05)
+        yield
+    finally:
+        if fd is not None:
+            unlock(fd)

--- a/routstr/redemption_cache.py
+++ b/routstr/redemption_cache.py
@@ -1,31 +1,18 @@
-"""In-memory negative cache for terminally failed Cashu token redemptions.
+"""Bounded local cache for failed Cashu token redemptions."""
 
-A dead token (already spent, malformed, zero value) presented as a bearer key
-triggers a full redemption attempt against the issuing mint on *every* request,
-because no ``api_keys`` row survives the failed attempt. Polling clients that
-never back off turn one dead token into thousands of pointless mint calls per
-day. This cache remembers terminal redemption failures by token hash so
-repeated presentations are rejected locally with the same error the mint
-attempt would have produced.
+from __future__ import annotations
 
-Only failures whose classification code is in :data:`TERMINAL_REDEMPTION_CODES`
-are cached — transient failures (mint unreachable, rate-limited, cooldown) must
-never be cached, or a brief mint outage would poison valid tokens.
-
-The cache is deliberately in-memory (bounded LRU with TTL) rather than a
-database row: persisting a row per failed token would let an attacker fill the
-database with garbage tokens for free.
-"""
-
+import math
+import os
+import re
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
-# Redemption ``code`` values that can never succeed on retry. A token that was
-# already spent, failed to decode, or redeemed to zero value stays that way
-# forever; swap fees exceeding the token amount only changes if the mint
-# lowers its fees, which the TTL covers.
+from . import node_coordination
+
 TERMINAL_REDEMPTION_CODES: frozenset[str] = frozenset(
     {
         "cashu_token_already_spent",
@@ -34,37 +21,49 @@ TERMINAL_REDEMPTION_CODES: frozenset[str] = frozenset(
         "cashu_token_swap_fees_exceed_amount",
     }
 )
+TRANSIENT_REDEMPTION_CODES: frozenset[str] = frozenset(
+    {
+        "cashu_mint_rate_limited",
+        "cashu_source_mint_unreachable",
+        "cashu_mint_unreachable",
+    }
+)
 
 DEFAULT_MAX_ENTRIES = 10_000
 DEFAULT_TTL_SECONDS = 24 * 60 * 60
+TRANSIENT_TTL_SECONDS = 30.0
+MAX_TRANSIENT_TTL_SECONDS = 60.0
+_HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 @dataclass(frozen=True)
 class CachedRedemptionFailure:
-    """Sanitized classification of a terminal redemption failure.
-
-    Mirrors the ``(type, status, message, code)`` tuple produced by
-    ``classify_redemption_error`` so a cache hit yields a byte-identical error
-    envelope to the original mint-backed failure.
-    """
-
     status_code: int
     error_type: str
     message: str
     code: str
 
 
-class RedemptionNegativeCache:
-    """Bounded TTL+LRU cache keyed by the SHA-256 hash of the bearer token.
+@dataclass(frozen=True)
+class _PersistedFailure:
+    expires_at: float
+    monotonic_until: float | None
+    boot_id: str | None
+    ttl_seconds: float | None
+    failure: CachedRedemptionFailure
 
-    Not thread-safe by design: all access happens on the asyncio event loop.
-    """
+
+class RedemptionNegativeCache:
+    """Memory LRU with an optional node-shared file tier."""
 
     def __init__(
         self,
         max_entries: int = DEFAULT_MAX_ENTRIES,
         ttl_seconds: float = DEFAULT_TTL_SECONDS,
         clock: Callable[[], float] = time.monotonic,
+        *,
+        storage_dir: Path | None = None,
+        wall_clock: Callable[[], float] = time.time,
     ) -> None:
         if max_entries <= 0:
             raise ValueError("max_entries must be positive")
@@ -73,37 +72,247 @@ class RedemptionNegativeCache:
         self._max_entries = max_entries
         self._ttl_seconds = ttl_seconds
         self._clock = clock
+        self._wall_clock = wall_clock
+        self._storage_dir = storage_dir
         self._entries: OrderedDict[str, tuple[float, CachedRedemptionFailure]] = (
             OrderedDict()
         )
 
-    def get(self, hashed_key: str) -> CachedRedemptionFailure | None:
-        entry = self._entries.get(hashed_key)
-        if entry is None:
+    def _path(self, hashed_key: str) -> Path | None:
+        if self._storage_dir is None or not _HASH_PATTERN.fullmatch(hashed_key):
             return None
-        expires_at, failure = entry
-        if self._clock() >= expires_at:
-            del self._entries[hashed_key]
-            return None
-        self._entries.move_to_end(hashed_key)
-        return failure
+        return self._storage_dir / hashed_key
 
-    def put(self, hashed_key: str, failure: CachedRedemptionFailure) -> None:
+    @staticmethod
+    def _decode(value: dict[str, object]) -> _PersistedFailure | None:
+        try:
+            version = value.get("version")
+            if version not in (1, 2):
+                return None
+            expires_at_value = value["expires_at"]
+            status_code_value = value["status_code"]
+            error_type = value["error_type"]
+            message = value["message"]
+            code = value["code"]
+        except KeyError:
+            return None
+        if (
+            not isinstance(expires_at_value, (int, float))
+            or isinstance(expires_at_value, bool)
+            or not isinstance(status_code_value, int)
+            or isinstance(status_code_value, bool)
+        ):
+            return None
+        expires_at = float(expires_at_value)
+        status_code = status_code_value
+        if (
+            not math.isfinite(expires_at)
+            or not 100 <= status_code <= 599
+            or not isinstance(error_type, str)
+            or not isinstance(message, str)
+            or not isinstance(code, str)
+            or len(error_type) > 128
+            or len(message) > 1024
+            or len(code) > 128
+        ):
+            return None
+
+        monotonic_until: float | None = None
+        boot_id: str | None = None
+        ttl_seconds: float | None = None
+        if version == 2:
+            monotonic_value = value.get("monotonic_until")
+            ttl_value = value.get("ttl_seconds")
+            boot_id_value = value.get("boot_id")
+            if (
+                not isinstance(monotonic_value, (int, float))
+                or isinstance(monotonic_value, bool)
+                or not isinstance(ttl_value, (int, float))
+                or isinstance(ttl_value, bool)
+                or not isinstance(boot_id_value, (str, type(None)))
+            ):
+                return None
+            monotonic_until = float(monotonic_value)
+            ttl_seconds = float(ttl_value)
+            if (
+                not math.isfinite(monotonic_until)
+                or not math.isfinite(ttl_seconds)
+                or ttl_seconds <= 0
+            ):
+                return None
+            boot_id = boot_id_value
+
+        return _PersistedFailure(
+            expires_at=expires_at,
+            monotonic_until=monotonic_until,
+            boot_id=boot_id,
+            ttl_seconds=ttl_seconds,
+            failure=CachedRedemptionFailure(
+                status_code=status_code,
+                error_type=error_type,
+                message=message,
+                code=code,
+            ),
+        )
+
+    def _remember(
+        self, hashed_key: str, failure: CachedRedemptionFailure, ttl_seconds: float
+    ) -> None:
         if hashed_key in self._entries:
             del self._entries[hashed_key]
         elif len(self._entries) >= self._max_entries:
             self._entries.popitem(last=False)
-        self._entries[hashed_key] = (self._clock() + self._ttl_seconds, failure)
+        self._entries[hashed_key] = (self._clock() + ttl_seconds, failure)
+
+    def get(self, hashed_key: str) -> CachedRedemptionFailure | None:
+        entry = self._entries.get(hashed_key)
+        if entry is not None:
+            expires_at, failure = entry
+            if self._clock() < expires_at:
+                self._entries.move_to_end(hashed_key)
+                return failure
+            del self._entries[hashed_key]
+
+        path = self._path(hashed_key)
+        if path is None:
+            return None
+        decoded = node_coordination.read_json(path)
+        parsed = self._decode(decoded) if decoded is not None else None
+        if parsed is None:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return None
+        if (
+            parsed.monotonic_until is not None
+            and parsed.boot_id is not None
+            and parsed.boot_id == node_coordination.NODE_BOOT_ID
+        ):
+            remaining = parsed.monotonic_until - self._clock()
+        else:
+            remaining = parsed.expires_at - self._wall_clock()
+        maximum_ttl = (
+            MAX_TRANSIENT_TTL_SECONDS
+            if parsed.failure.code in TRANSIENT_REDEMPTION_CODES
+            else self._ttl_seconds
+        )
+        if parsed.ttl_seconds is not None:
+            maximum_ttl = min(maximum_ttl, parsed.ttl_seconds)
+        if not math.isfinite(remaining) or remaining <= 0:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return None
+        remaining = min(remaining, maximum_ttl)
+        if (
+            node_coordination.NODE_BOOT_ID is not None
+            and parsed.boot_id != node_coordination.NODE_BOOT_ID
+        ):
+            try:
+                self._write_shared(path, parsed.failure, remaining)
+            except OSError:
+                pass
+        self._remember(hashed_key, parsed.failure, remaining)
+        return parsed.failure
+
+    def _write_shared(
+        self,
+        path: Path,
+        failure: CachedRedemptionFailure,
+        ttl_seconds: float,
+    ) -> None:
+        node_coordination.write_json(
+            path,
+            {
+                "version": 2,
+                "boot_id": node_coordination.NODE_BOOT_ID,
+                "monotonic_until": self._clock() + ttl_seconds,
+                "expires_at": self._wall_clock() + ttl_seconds,
+                "ttl_seconds": ttl_seconds,
+                "status_code": failure.status_code,
+                "error_type": failure.error_type,
+                "message": failure.message,
+                "code": failure.code,
+            },
+        )
+
+    def put(
+        self,
+        hashed_key: str,
+        failure: CachedRedemptionFailure,
+        *,
+        ttl_seconds: float | None = None,
+    ) -> None:
+        ttl = self._ttl_seconds if ttl_seconds is None else ttl_seconds
+        if not math.isfinite(ttl) or ttl <= 0:
+            raise ValueError("ttl_seconds must be positive and finite")
+        if failure.code in TRANSIENT_REDEMPTION_CODES:
+            ttl = min(ttl, MAX_TRANSIENT_TTL_SECONDS)
+        self._remember(hashed_key, failure, ttl)
+        path = self._path(hashed_key)
+        if path is None:
+            return
+        try:
+            self._write_shared(path, failure, ttl)
+            self._trim_shared()
+        except OSError:
+            # The memory tier is sufficient for correctness in this process.
+            return
+
+    def _trim_shared(self) -> None:
+        if self._storage_dir is None:
+            return
+        try:
+            files = [
+                entry for entry in os.scandir(self._storage_dir) if entry.is_file()
+            ]
+        except OSError:
+            return
+        if len(files) <= self._max_entries:
+            return
+        dated_files: list[tuple[float, os.DirEntry[str]]] = []
+        for entry in files:
+            try:
+                dated_files.append((entry.stat().st_mtime, entry))
+            except OSError:
+                continue
+        dated_files.sort(key=lambda item: item[0])
+        for _, entry in dated_files[: len(dated_files) - self._max_entries]:
+            try:
+                os.unlink(entry.path)
+            except OSError:
+                pass
 
     def discard(self, hashed_key: str) -> None:
         self._entries.pop(hashed_key, None)
+        path = self._path(hashed_key)
+        if path is not None:
+            try:
+                path.unlink()
+            except OSError:
+                pass
 
-    def clear(self) -> None:
+    def clear(self, *, shared: bool = False) -> None:
         self._entries.clear()
+        if not shared or self._storage_dir is None:
+            return
+        try:
+            files = list(os.scandir(self._storage_dir))
+        except OSError:
+            return
+        for entry in files:
+            if entry.is_file() and _HASH_PATTERN.fullmatch(entry.name):
+                try:
+                    os.unlink(entry.path)
+                except OSError:
+                    pass
 
     def __len__(self) -> int:
         return len(self._entries)
 
 
-# Process-wide singleton used by the bearer-auth path.
-redemption_negative_cache = RedemptionNegativeCache()
+redemption_negative_cache = RedemptionNegativeCache(
+    storage_dir=node_coordination.NODE_STATE_DIR / "redemption-failures"
+)

--- a/routstr/upstream/auto_topup.py
+++ b/routstr/upstream/auto_topup.py
@@ -4,11 +4,13 @@ import math
 import time
 import typing
 import uuid
+from pathlib import Path
 
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, or_, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from .. import node_coordination
 from ..core import get_logger
 from ..core.db import (
     CashuTransaction,
@@ -228,26 +230,129 @@ async def _check_and_topup(row: UpstreamProviderRow) -> None:
         )
         return
 
-    if not row.api_key:
+    if not row.api_key or row.id is None:
         return
 
-    # Instantiate provider and check balance
+    lock_fd = node_coordination.try_lock(_routstr_topup_lock_path(row.id))
+    if lock_fd is None:
+        logger.debug(
+            "Skipping overlapping auto top-up check",
+            extra={"provider_id": row.id},
+        )
+        return
+    try:
+        await _check_and_topup_routstr_locked(
+            row, threshold=threshold, amount=amount, mint_url=mint_url
+        )
+    finally:
+        node_coordination.unlock(lock_fd)
+
+
+def _routstr_topup_lock_path(provider_id: int | str) -> Path:
+    return (
+        node_coordination.NODE_STATE_DIR
+        / "auto-topup"
+        / f"{node_coordination.state_key(str(provider_id))}.lock"
+    )
+
+
+async def _pending_routstr_topup(
+    provider_id: int | str,
+) -> CashuTransaction | None:
+    request_id = f"routstr-auto-topup:{provider_id}"
+    async with create_session() as session:
+        return (
+            await session.exec(
+                select(CashuTransaction).where(
+                    CashuTransaction.type == "out",
+                    CashuTransaction.source == "auto_topup",
+                    CashuTransaction.request_id == request_id,
+                    CashuTransaction.collected == False,  # noqa: E712
+                    CashuTransaction.swept == False,  # noqa: E712
+                )
+            )
+        ).first()
+
+
+async def _has_pending_routstr_topup(provider_id: int | str) -> bool:
+    return await _pending_routstr_topup(provider_id) is not None
+
+
+async def get_routstr_auto_topup_state(provider_id: int) -> dict[str, object]:
+    """Return the pending reservation without exposing its bearer token."""
+    transaction = await _pending_routstr_topup(provider_id)
+    if transaction is None:
+        return {"active": False}
+    return {
+        "active": True,
+        "state_token": transaction.id,
+        "created_at": transaction.created_at,
+        "amount": transaction.amount,
+        "unit": transaction.unit,
+        "mint_url": transaction.mint_url,
+    }
+
+
+class RoutstrReleaseOutcome(typing.NamedTuple):
+    released: bool
+    reason: str
+
+
+async def release_routstr_auto_topup_state(
+    provider_id: int, *, state_token: str | None
+) -> RoutstrReleaseOutcome:
+    """Release a reservation after an operator confirms the token was not used."""
+    async with node_coordination.exclusive_lock(_routstr_topup_lock_path(provider_id)):
+        transaction = await _pending_routstr_topup(provider_id)
+        if transaction is None:
+            return RoutstrReleaseOutcome(False, "no_active_reservation")
+        if transaction.id != state_token:
+            return RoutstrReleaseOutcome(False, "stale_state")
+
+        await release_token_reservation(transaction.token)
+        async with create_session() as session:
+            result = await session.exec(  # type: ignore[call-overload]
+                update(CashuTransaction)
+                .where(
+                    col(CashuTransaction.id) == state_token,
+                    col(CashuTransaction.request_id)
+                    == f"routstr-auto-topup:{provider_id}",
+                    col(CashuTransaction.source) == "auto_topup",
+                    col(CashuTransaction.collected) == False,  # noqa: E712
+                    col(CashuTransaction.swept) == False,  # noqa: E712
+                )
+                .values(swept=True)
+            )
+            if (getattr(result, "rowcount", 0) or 0) != 1:
+                await session.rollback()
+                return RoutstrReleaseOutcome(False, "reservation_changed")
+            await session.commit()
+    return RoutstrReleaseOutcome(True, "released")
+
+
+async def _check_and_topup_routstr_locked(
+    row: UpstreamProviderRow, *, threshold: float, amount: int, mint_url: str
+) -> None:
+    if row.id is None or await _has_pending_routstr_topup(row.id):
+        logger.warning(
+            "Skipping auto top-up while a previous token needs reconciliation",
+            extra={"provider_id": row.id},
+        )
+        return
+
     provider = RoutstrUpstreamProvider.from_db_row(row)
     if provider is None:
         return
     balance = await provider.get_balance()
-
     if balance is None:
         logger.warning(
             "Could not fetch balance for auto top-up",
             extra={"provider_id": row.id, "base_url": row.base_url},
         )
         return
-
     if balance >= threshold * 1000:
         return
 
-    # Balance is below threshold - create token and top up
     logger.info(
         "Auto top-up triggered",
         extra={
@@ -258,22 +363,22 @@ async def _check_and_topup(row: UpstreamProviderRow) -> None:
             "mint_url": mint_url,
         },
     )
-
     try:
         token = await send_token(amount, "sat", mint_url)
-    except Exception as e:
+    except Exception as error:
         logger.error(
             "Failed to create cashu token for auto top-up",
             extra={
                 "provider_id": row.id,
                 "amount": amount,
                 "mint_url": mint_url,
-                "error": str(e),
+                "error": str(error),
             },
         )
         return
 
     actual_mint_url = token_mint_url(token, mint_url)
+    request_id = f"routstr-auto-topup:{row.id}"
     try:
         await store_cashu_transaction(
             token=token,
@@ -281,6 +386,7 @@ async def _check_and_topup(row: UpstreamProviderRow) -> None:
             unit="sat",
             mint_url=actual_mint_url,
             typ="out",
+            request_id=request_id,
             collected=False,
             source="auto_topup",
         )
@@ -308,44 +414,48 @@ async def _check_and_topup(row: UpstreamProviderRow) -> None:
         return
 
     result = await provider.topup(token)
-
     if "error" in result:
         logger.error(
-            "Auto top-up upstream call failed",
+            "Auto top-up upstream call failed; token requires manual reconciliation",
             extra={
                 "provider_id": row.id,
                 "error": result["error"],
+                "admin_action": (
+                    f"GET /admin/api/upstream-providers/{row.id}/routstr-auto-topup"
+                ),
             },
         )
-    else:
-        async with create_session() as session:
-            transaction = (
-                await session.exec(
-                    select(CashuTransaction).where(
-                        CashuTransaction.token == token,
-                        CashuTransaction.type == "out",
-                        CashuTransaction.source == "auto_topup",
-                    )
-                )
-            ).first()
-            if transaction is None:
-                logger.critical(
-                    "Completed auto top-up transaction is missing from the database",
-                    extra={"provider_id": row.id, "mint_url": mint_url},
-                )
-            else:
-                transaction.collected = True
-                session.add(transaction)
-                await session.commit()
+        return
 
-        logger.info(
-            "Auto top-up completed successfully",
-            extra={
-                "provider_id": row.id,
-                "amount": amount,
-                "new_balance_approx": balance + amount,
-            },
-        )
+    async with create_session() as session:
+        transaction = (
+            await session.exec(
+                select(CashuTransaction).where(
+                    CashuTransaction.token == token,
+                    CashuTransaction.type == "out",
+                    CashuTransaction.source == "auto_topup",
+                    CashuTransaction.request_id == request_id,
+                )
+            )
+        ).first()
+        if transaction is None:
+            logger.critical(
+                "Completed auto top-up transaction is missing from the database",
+                extra={"provider_id": row.id, "mint_url": mint_url},
+            )
+        else:
+            transaction.collected = True
+            session.add(transaction)
+            await session.commit()
+
+    logger.info(
+        "Auto top-up completed successfully",
+        extra={
+            "provider_id": row.id,
+            "amount": amount,
+            "new_balance_approx": balance + amount,
+        },
+    )
 
 
 def _ppq_state_id(row: UpstreamProviderRow) -> str:

--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -1,6 +1,7 @@
 import asyncio
 import fcntl
 import json
+import math
 import os
 import re
 import time
@@ -19,6 +20,7 @@ from cashu.wallet.wallet import Wallet as _CashuWallet
 from pydantic_core import PydanticUndefined
 from sqlmodel import col, select, update
 
+from . import node_coordination
 from .core import db, get_logger
 from .core.db import store_cashu_transaction_with_retry as store_cashu_transaction
 from .core.settings import settings
@@ -64,6 +66,9 @@ _WALLET_OPERATION_LOCK = Path(".wallet") / ".routstr-operation.lock"
 _wallet_operation_depth: ContextVar[int] = ContextVar(
     "wallet_operation_depth", default=0
 )
+_wallet_operation_started_at: ContextVar[float | None] = ContextVar(
+    "wallet_operation_started_at", default=None
+)
 
 
 @asynccontextmanager
@@ -82,6 +87,7 @@ async def wallet_operation_guard() -> AsyncGenerator[None, None]:
     fd = os.open(_WALLET_OPERATION_LOCK, os.O_CREAT | os.O_RDWR, 0o600)
     acquired = False
     depth_token = None
+    started_token = None
     try:
         while not acquired:
             try:
@@ -90,9 +96,12 @@ async def wallet_operation_guard() -> AsyncGenerator[None, None]:
             except BlockingIOError:
                 await _scheduler_sleep(0.05)
         depth_token = _wallet_operation_depth.set(1)
+        started_token = _wallet_operation_started_at.set(time.time())
         async with fail_fast_mint_operations():
             yield
     finally:
+        if started_token is not None:
+            _wallet_operation_started_at.reset(started_token)
         if depth_token is not None:
             _wallet_operation_depth.reset(depth_token)
         if acquired:
@@ -1805,6 +1814,34 @@ _wallet_load_locks: dict[str, asyncio.Lock] = {}
 _WALLOAD_RELOAD_MIN_INTERVAL_SECONDS = 30
 
 
+def _wallet_refresh_paths(wallet_id: str) -> tuple[Path, Path]:
+    key = node_coordination.state_key(wallet_id)
+    directory = node_coordination.NODE_STATE_DIR / "wallet-refresh"
+    return directory / f"{key}.json", directory / f"{key}.lock"
+
+
+def _wallet_refreshed_at(path: Path) -> float | None:
+    value = node_coordination.read_json(path)
+    if value is None or value.get("version") != 1:
+        return None
+    refreshed_at = value.get("refreshed_at")
+    if not isinstance(refreshed_at, (int, float)):
+        return None
+    now = time.time()
+    if refreshed_at < 0 or refreshed_at > now + 60:
+        return None
+    return float(refreshed_at)
+
+
+async def _load_wallet_from_shared_db(wallet: Wallet) -> bool:
+    try:
+        await wallet.load_proofs(reload=True)
+        await wallet.activate_keyset()
+    except Exception:
+        return False
+    return bool(wallet.keysets)
+
+
 async def get_wallet(
     mint_url: str,
     unit: str = "sat",
@@ -1822,24 +1859,38 @@ async def get_wallet(
         if load:
             now = time.monotonic()
             last = _wallet_last_load.get(id)
-            if (
+            needs_reload = (
                 force_reload
                 or last is None
                 or now - last >= _WALLOAD_RELOAD_MIN_INTERVAL_SECONDS
-            ):
-                await run_mint_operation(
-                    lambda: _wallets[id].load_mint(),
-                    op_name="load_mint",
-                    mint_url=mint_url,
-                    retry_on_rate_limit=retry_on_rate_limit,
-                )
-                await run_mint_operation(
-                    lambda: _wallets[id].load_proofs(reload=True),
-                    op_name="load_proofs",
-                    mint_url=mint_url,
-                    retry_on_rate_limit=retry_on_rate_limit,
-                )
-                _wallet_last_load[id] = time.monotonic()
+            )
+            if needs_reload:
+                marker_path, marker_lock_path = _wallet_refresh_paths(id)
+                requested_at = _wallet_operation_started_at.get() or time.time()
+                async with node_coordination.exclusive_lock(marker_lock_path):
+                    refreshed_at = _wallet_refreshed_at(marker_path)
+                    shared_refresh_is_fresh = refreshed_at is not None and (
+                        refreshed_at >= requested_at
+                        if force_reload
+                        else time.time() - refreshed_at
+                        < _WALLOAD_RELOAD_MIN_INTERVAL_SECONDS
+                    )
+                    loaded_locally = False
+                    if shared_refresh_is_fresh:
+                        loaded_locally = await _load_wallet_from_shared_db(_wallets[id])
+                    if not loaded_locally:
+                        await run_mint_operation(
+                            lambda: _wallets[id].load_mint(),
+                            op_name="load_mint",
+                            mint_url=mint_url,
+                            retry_on_rate_limit=retry_on_rate_limit,
+                        )
+                        node_coordination.write_json(
+                            marker_path,
+                            {"version": 1, "refreshed_at": time.time()},
+                        )
+                        await _wallets[id].load_proofs(reload=True)
+                    _wallet_last_load[id] = time.monotonic()
         return _wallets[id]
 
 
@@ -1906,37 +1957,175 @@ _balance_fetch_locks: dict[str, asyncio.Lock] = {}
 _mint_supported_units: dict[str, tuple[float, list[str]]] = {}
 
 
+class CachedMintUnitDiscoveryError(Exception):
+    def __init__(self, message: str, error_code: str):
+        self.error_code = error_code
+        super().__init__(message)
+
+
+def _mint_units_paths(mint_url: str) -> tuple[Path, Path]:
+    key = node_coordination.state_key(mint_url)
+    directory = node_coordination.NODE_STATE_DIR / "mint-units"
+    return directory / f"{key}.json", directory / f"{key}.lock"
+
+
+def _shared_mint_units_remaining(
+    state: dict[str, object], maximum_ttl: float
+) -> float | None:
+    version = state.get("version")
+    expires_at = state.get("expires_at")
+    if (
+        version not in (1, 2)
+        or not isinstance(expires_at, (int, float))
+        or isinstance(expires_at, bool)
+    ):
+        return None
+    wall_deadline = float(expires_at)
+    if not math.isfinite(wall_deadline):
+        return None
+
+    remaining = wall_deadline - time.time()
+    if version == 2:
+        monotonic_until = state.get("monotonic_until")
+        ttl_seconds = state.get("ttl_seconds")
+        boot_id = state.get("boot_id")
+        if (
+            not isinstance(monotonic_until, (int, float))
+            or isinstance(monotonic_until, bool)
+            or not isinstance(ttl_seconds, (int, float))
+            or isinstance(ttl_seconds, bool)
+            or not isinstance(boot_id, (str, type(None)))
+        ):
+            return None
+        monotonic_deadline = float(monotonic_until)
+        persisted_ttl = float(ttl_seconds)
+        if (
+            not math.isfinite(monotonic_deadline)
+            or not math.isfinite(persisted_ttl)
+            or persisted_ttl <= 0
+        ):
+            return None
+        maximum_ttl = min(maximum_ttl, persisted_ttl)
+        if boot_id is not None and boot_id == node_coordination.NODE_BOOT_ID:
+            remaining = monotonic_deadline - time.monotonic()
+
+    if not math.isfinite(remaining) or remaining <= 0:
+        return None
+    return min(remaining, maximum_ttl)
+
+
+def _mint_units_cache_state(ttl_seconds: float) -> dict[str, object]:
+    return {
+        "version": 2,
+        "boot_id": node_coordination.NODE_BOOT_ID,
+        "monotonic_until": time.monotonic() + ttl_seconds,
+        "expires_at": time.time() + ttl_seconds,
+        "ttl_seconds": ttl_seconds,
+    }
+
+
+def _write_mint_units_state(
+    path: Path, state: dict[str, object], mint_url: str
+) -> None:
+    try:
+        node_coordination.write_json(path, state)
+    except (OSError, ValueError) as error:
+        logger.warning(
+            "Unable to persist mint unit discovery cache",
+            extra={"mint_url": mint_url, "error": str(error)},
+        )
+
+
+def _migrate_mint_units_state(
+    path: Path, state: dict[str, object], remaining: float, mint_url: str
+) -> None:
+    if (
+        node_coordination.NODE_BOOT_ID is None
+        or state.get("boot_id") == node_coordination.NODE_BOOT_ID
+    ):
+        return
+    migrated = _mint_units_cache_state(remaining)
+    for key in ("units", "error", "error_code"):
+        if key in state:
+            migrated[key] = state[key]
+    _write_mint_units_state(path, migrated, mint_url)
+
+
 async def _get_supported_mint_units(mint_url: str) -> list[str]:
     now = time.monotonic()
     cached = _mint_supported_units.get(mint_url)
     if cached is not None and now < cached[0]:
         return cached[1]
 
-    wallet = await get_wallet(mint_url, settings.primary_mint_unit, load=False)
-    keysets = await run_mint_operation(
-        lambda: wallet._get_keysets(),
-        op_name="get_mint_keysets",
-        mint_url=mint_url,
-        retry_on_rate_limit=False,
-    )
-    units: list[str] = []
-    for keyset in keysets:
-        if not keyset.active or keyset.unit is None:
-            continue
-        unit = keyset.unit if isinstance(keyset.unit, str) else keyset.unit.name
-        if unit and unit not in units:
-            units.append(unit)
-    if not units:
-        units = [settings.primary_mint_unit]
-    elif settings.primary_mint_unit in units:
-        units.remove(settings.primary_mint_unit)
-        units.insert(0, settings.primary_mint_unit)
+    state_path, lock_path = _mint_units_paths(mint_url)
+    async with node_coordination.exclusive_lock(lock_path):
+        state = node_coordination.read_json(state_path)
+        if state is not None:
+            units = state.get("units")
+            maximum_ttl = (
+                _MINT_UNITS_CACHE_SECONDS
+                if isinstance(units, list)
+                else _BALANCE_FETCH_RETRY_SECONDS
+            )
+            remaining = _shared_mint_units_remaining(state, maximum_ttl)
+            if remaining is not None:
+                if isinstance(units, list) and all(
+                    isinstance(unit, str) for unit in units
+                ):
+                    _migrate_mint_units_state(state_path, state, remaining, mint_url)
+                    _mint_supported_units[mint_url] = (
+                        time.monotonic() + remaining,
+                        units,
+                    )
+                    return units
+                error = state.get("error")
+                error_code = state.get("error_code")
+                if isinstance(error, str) and isinstance(error_code, str):
+                    _migrate_mint_units_state(state_path, state, remaining, mint_url)
+                    raise CachedMintUnitDiscoveryError(error, error_code)
 
-    _mint_supported_units[mint_url] = (
-        time.monotonic() + _MINT_UNITS_CACHE_SECONDS,
-        units,
-    )
-    return units
+        wallet = await get_wallet(mint_url, settings.primary_mint_unit, load=False)
+        try:
+            keysets = await run_mint_operation(
+                lambda: wallet._get_keysets(),
+                op_name="get_mint_keysets",
+                mint_url=mint_url,
+                retry_on_rate_limit=False,
+            )
+        except Exception as error:
+            error_code = (
+                "rate_limited"
+                if is_mint_rate_limited(error)
+                else "unreachable"
+                if is_mint_connection_error(error)
+                else "mint_error"
+            )
+            failure_state = _mint_units_cache_state(_BALANCE_FETCH_RETRY_SECONDS)
+            failure_state.update({"error": str(error)[:1024], "error_code": error_code})
+            _write_mint_units_state(state_path, failure_state, mint_url)
+            raise
+
+        units: list[str] = []
+        for keyset in keysets:
+            if not keyset.active or keyset.unit is None:
+                continue
+            unit = keyset.unit if isinstance(keyset.unit, str) else keyset.unit.name
+            if unit and unit not in units:
+                units.append(unit)
+        if not units:
+            units = [settings.primary_mint_unit]
+        elif settings.primary_mint_unit in units:
+            units.remove(settings.primary_mint_unit)
+            units.insert(0, settings.primary_mint_unit)
+
+        supported_state = _mint_units_cache_state(_MINT_UNITS_CACHE_SECONDS)
+        supported_state["units"] = units
+        _write_mint_units_state(state_path, supported_state, mint_url)
+        _mint_supported_units[mint_url] = (
+            time.monotonic() + _MINT_UNITS_CACHE_SECONDS,
+            units,
+        )
+        return units
 
 
 def _balance_error(
@@ -1976,16 +2165,21 @@ async def fetch_all_balances(
             try:
                 mint_units[mint_url] = await _get_supported_mint_units(mint_url)
             except Exception as error:
-                connection_failure = is_mint_connection_error(error)
-                rate_limited = is_mint_rate_limited(error)
-                error_code = (
+                cached_error_code = getattr(error, "error_code", None)
+                connection_failure = cached_error_code == "unreachable" or (
+                    cached_error_code is None and is_mint_connection_error(error)
+                )
+                rate_limited = cached_error_code == "rate_limited" or (
+                    cached_error_code is None and is_mint_rate_limited(error)
+                )
+                error_code = cached_error_code or (
                     "rate_limited"
                     if rate_limited
                     else "unreachable"
                     if connection_failure
                     else "mint_error"
                 )
-                if connection_failure:
+                if connection_failure and cached_error_code is None:
                     MintRateGuard.get(mint_url).apply_cooldown(
                         _BALANCE_FETCH_RETRY_SECONDS, reason="unreachable"
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ absent one) override this per-test via ``monkeypatch``.
 """
 
 import os
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -19,15 +20,23 @@ os.environ.setdefault("ROUTSTR_SECRET_KEY", TEST_SECRET_KEY)
 
 
 @pytest.fixture(autouse=True)
-def _isolate_redemption_negative_cache() -> Iterator[None]:
+def _isolate_redemption_negative_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
     """Clear the process-wide negative cache between tests.
 
     The cache deliberately persists terminal redemption failures across
     requests; without this fixture a test that burns a token would poison
     every later test reusing the same token string.
     """
+    from routstr import node_coordination
     from routstr.redemption_cache import redemption_negative_cache
 
-    redemption_negative_cache.clear()
+    state_dir = tmp_path / ".routstr-node"
+    monkeypatch.setattr(node_coordination, "NODE_STATE_DIR", state_dir)
+    monkeypatch.setattr(
+        redemption_negative_cache, "_storage_dir", state_dir / "redemption-failures"
+    )
+    redemption_negative_cache.clear(shared=True)
     yield
-    redemption_negative_cache.clear()
+    redemption_negative_cache.clear(shared=True)

--- a/tests/integration/test_routstr_auto_topup_recovery.py
+++ b/tests/integration/test_routstr_auto_topup_recovery.py
@@ -1,0 +1,123 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from routstr import node_coordination
+from routstr.core.db import CashuTransaction, create_session
+from routstr.upstream.auto_topup import (
+    _routstr_topup_lock_path,
+    get_routstr_auto_topup_state,
+    release_routstr_auto_topup_state,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_pending(provider_id: int = 1) -> CashuTransaction:
+    transaction = CashuTransaction(
+        id="routstr-reservation-1",
+        token="cashu-bearer-token",
+        amount=50,
+        unit="sat",
+        type="out",
+        request_id=f"routstr-auto-topup:{provider_id}",
+        mint_url="https://mint.test",
+        collected=False,
+        swept=False,
+        source="auto_topup",
+    )
+    async with create_session() as session:
+        session.add(transaction)
+        await session.commit()
+    return transaction
+
+
+async def test_release_endpoint_requires_explicit_confirmation(
+    patched_db_engine: Any,
+) -> None:
+    from routstr.core.admin import (
+        ReleaseRoutstrAutoTopupRequest,
+        release_routstr_auto_topup_api,
+    )
+
+    with patch("routstr.core.admin._require_routstr_provider", new=AsyncMock()):
+        with pytest.raises(HTTPException) as caught:
+            await release_routstr_auto_topup_api(
+                1,
+                ReleaseRoutstrAutoTopupRequest(
+                    confirmed_token_was_not_used=False,
+                    state_token="routstr-reservation-1",
+                ),
+            )
+
+    assert caught.value.status_code == 400
+
+
+async def test_state_hides_bearer_token(patched_db_engine: Any) -> None:
+    transaction = await _seed_pending()
+
+    state = await get_routstr_auto_topup_state(1)
+
+    assert state == {
+        "active": True,
+        "state_token": transaction.id,
+        "created_at": transaction.created_at,
+        "amount": 50,
+        "unit": "sat",
+        "mint_url": "https://mint.test",
+    }
+    assert "token" not in state
+
+
+async def test_release_requires_the_reviewed_state_token(
+    patched_db_engine: Any,
+) -> None:
+    await _seed_pending()
+
+    with patch(
+        "routstr.upstream.auto_topup.release_token_reservation", new=AsyncMock()
+    ) as release:
+        outcome = await release_routstr_auto_topup_state(1, state_token="stale")
+
+    assert outcome.released is False
+    assert outcome.reason == "stale_state"
+    release.assert_not_awaited()
+
+
+async def test_release_waits_for_active_topup(
+    patched_db_engine: Any,
+) -> None:
+    transaction = await _seed_pending()
+    with patch(
+        "routstr.upstream.auto_topup.release_token_reservation", new=AsyncMock()
+    ):
+        async with node_coordination.exclusive_lock(_routstr_topup_lock_path(1)):
+            release = asyncio.create_task(
+                release_routstr_auto_topup_state(1, state_token=transaction.id)
+            )
+            await asyncio.sleep(0.05)
+            assert not release.done()
+        outcome = await release
+
+    assert outcome.released is True
+
+
+async def test_release_frees_token_and_closes_pending_row(
+    patched_db_engine: Any,
+) -> None:
+    transaction = await _seed_pending()
+
+    with patch(
+        "routstr.upstream.auto_topup.release_token_reservation", new=AsyncMock()
+    ) as release:
+        outcome = await release_routstr_auto_topup_state(1, state_token=transaction.id)
+
+    assert outcome.released is True
+    release.assert_awaited_once_with("cashu-bearer-token")
+    async with create_session() as session:
+        stored = await session.get(CashuTransaction, transaction.id)
+    assert stored is not None and stored.swept is True
+    assert await get_routstr_auto_topup_state(1) == {"active": False}

--- a/tests/unit/test_auth_cashu.py
+++ b/tests/unit/test_auth_cashu.py
@@ -73,6 +73,86 @@ async def test_failed_first_cashu_redemption_rolls_back_empty_api_key(
     assert await session.get(ApiKey, hashed_key) is None
 
 
+@pytest.mark.asyncio
+async def test_transient_redemption_retry_is_suppressed(
+    session: AsyncSession,
+) -> None:
+    token = "cashuAtransient_retry"
+    token_obj = SimpleNamespace(mint="http://mint:3338", unit="sat")
+    credit = AsyncMock(side_effect=httpx.ConnectError("mint unavailable"))
+
+    from routstr.core.settings import settings
+
+    with (
+        patch.object(settings, "cashu_mints", ["http://mint:3338"]),
+        patch("routstr.auth.deserialize_token_from_string", return_value=token_obj),
+        patch("routstr.auth.credit_balance", new=credit),
+    ):
+        for _ in range(2):
+            with pytest.raises(HTTPException) as caught:
+                await validate_bearer_key(token, session)
+            assert caught.value.status_code == 503
+
+    credit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shared_failure_cache_io_does_not_mask_mint_outage(
+    session: AsyncSession,
+) -> None:
+    token = "cashuAshared_cache_io_failure"
+    token_obj = SimpleNamespace(mint="http://mint:3338", unit="sat")
+
+    from routstr.core.settings import settings
+
+    with (
+        patch.object(settings, "cashu_mints", ["http://mint:3338"]),
+        patch("routstr.auth.deserialize_token_from_string", return_value=token_obj),
+        patch(
+            "routstr.auth.credit_balance",
+            new=AsyncMock(side_effect=httpx.ConnectError("mint unavailable")),
+        ),
+        patch(
+            "routstr.redemption_cache.node_coordination.write_json",
+            side_effect=OSError("disk unavailable"),
+        ),
+    ):
+        with pytest.raises(HTTPException) as caught:
+            await validate_bearer_key(token, session)
+
+    assert caught.value.status_code == 503
+    assert caught.value.detail["error"]["code"] == "cashu_mint_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_transient_redemption_retry_recovers_after_expiry(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from routstr.redemption_cache import redemption_negative_cache
+
+    now = 0.0
+    monkeypatch.setattr(redemption_negative_cache, "_clock", lambda: now)
+    monkeypatch.setattr(redemption_negative_cache, "_wall_clock", lambda: now)
+    token = "cashuAtransient_retry_after_expiry"
+    token_obj = SimpleNamespace(mint="http://mint:3338", unit="sat")
+    credit = AsyncMock(side_effect=[httpx.ConnectError("mint unavailable"), 1_000])
+
+    from routstr.core.settings import settings
+
+    with (
+        patch.object(settings, "cashu_mints", ["http://mint:3338"]),
+        patch("routstr.auth.deserialize_token_from_string", return_value=token_obj),
+        patch("routstr.auth.credit_balance", new=credit),
+    ):
+        with pytest.raises(HTTPException):
+            await validate_bearer_key(token, session)
+        now = 31.0
+        key = await validate_bearer_key(token, session)
+
+    assert key.hashed_key == hashlib.sha256(token.encode()).hexdigest()
+    assert credit.await_count == 2
+
+
 @pytest.mark.parametrize(
     ("error", "expected_status", "expected_type", "expected_message", "expected_code"),
     [

--- a/tests/unit/test_auto_topup.py
+++ b/tests/unit/test_auto_topup.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,6 +28,15 @@ async def test_ppq_balance_rejects_boolean_api_value() -> None:
     provider.check_balance = AsyncMock(return_value={"balance": False})  # type: ignore[method-assign]
 
     assert await provider.get_balance() is None
+
+
+@pytest.fixture(autouse=True)
+def _no_pending_routstr_topup(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    pending = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        "routstr.upstream.auto_topup._has_pending_routstr_topup", pending
+    )
+    return pending
 
 
 def _row() -> MagicMock:
@@ -103,6 +113,7 @@ async def test_auto_topup_persists_before_sending_and_marks_success_collected() 
         unit="sat",
         mint_url="https://fallback-mint.test",
         typ="out",
+        request_id="routstr-auto-topup:provider-1",
         collected=False,
         source="auto_topup",
     )
@@ -174,6 +185,101 @@ async def test_auto_topup_does_not_send_untracked_token() -> None:
 
     reclaim.assert_awaited_once_with("cashu-token")
     provider.topup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_auto_topups_create_one_token(
+    _no_pending_routstr_topup: AsyncMock,
+) -> None:
+    persisted = False
+    transaction = CashuTransaction(
+        token="cashu-token", amount=50, unit="sat", source="auto_topup"
+    )
+    topup_started = asyncio.Event()
+    finish_topup = asyncio.Event()
+
+    async def has_pending(_: object) -> bool:
+        return persisted and not transaction.collected
+
+    async def store(**_: object) -> bool:
+        nonlocal persisted
+        persisted = True
+        return True
+
+    async def topup(_: str) -> dict[str, int]:
+        topup_started.set()
+        await finish_topup.wait()
+        return {"balance": 50}
+
+    provider = MagicMock()
+    provider.get_balance = AsyncMock(return_value=0)
+    provider.topup = AsyncMock(side_effect=topup)
+    _no_pending_routstr_topup.side_effect = has_pending
+
+    with (
+        patch(
+            "routstr.upstream.auto_topup.RoutstrUpstreamProvider.from_db_row",
+            return_value=provider,
+        ),
+        patch(
+            "routstr.upstream.auto_topup.send_token",
+            AsyncMock(return_value="cashu-token"),
+        ) as send,
+        patch(
+            "routstr.upstream.auto_topup.store_cashu_transaction",
+            AsyncMock(side_effect=store),
+        ),
+        patch(
+            "routstr.upstream.auto_topup.create_session",
+            return_value=_Session(transaction),
+        ),
+    ):
+        first = asyncio.create_task(_check_and_topup(_row()))
+        await topup_started.wait()
+        second = asyncio.create_task(_check_and_topup(_row()))
+        try:
+            await asyncio.sleep(0.1)
+            assert _no_pending_routstr_topup.await_count == 1
+        finally:
+            finish_topup.set()
+            await asyncio.gather(first, second)
+
+    assert transaction.collected is True
+    assert _no_pending_routstr_topup.await_count == 1
+    send.assert_awaited_once()
+    provider.topup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pending_auto_topup_blocks_new_token(
+    _no_pending_routstr_topup: AsyncMock,
+) -> None:
+    _no_pending_routstr_topup.return_value = True
+    with (
+        patch(
+            "routstr.upstream.auto_topup.RoutstrUpstreamProvider.from_db_row"
+        ) as provider_factory,
+        patch("routstr.upstream.auto_topup.send_token", AsyncMock()) as send,
+    ):
+        await _check_and_topup(_row())
+
+    provider_factory.assert_not_called()
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_topup_lock_is_released_after_exception() -> None:
+    provider = MagicMock()
+    provider.get_balance = AsyncMock(side_effect=[RuntimeError("failed"), 200_000])
+    with patch(
+        "routstr.upstream.auto_topup.RoutstrUpstreamProvider.from_db_row",
+        return_value=provider,
+    ):
+        first = await asyncio.gather(_check_and_topup(_row()), return_exceptions=True)
+        await _check_and_topup(_row())
+
+    assert isinstance(first[0], RuntimeError)
+    assert provider.get_balance.await_count == 2
 
 
 def _ppq_row() -> MagicMock:

--- a/tests/unit/test_fetch_all_balances.py
+++ b/tests/unit/test_fetch_all_balances.py
@@ -151,6 +151,245 @@ async def test_supported_mint_units_come_from_active_keysets() -> None:
     wallet._get_keysets.assert_awaited_once()
 
 
+@pytest.mark.parametrize(
+    "write_error",
+    [OSError("disk full"), ValueError("cache state too large")],
+    ids=["os-error", "value-error"],
+)
+@pytest.mark.asyncio
+async def test_supported_mint_units_survive_cache_write_failure(
+    write_error: Exception,
+) -> None:
+    from routstr.wallet import _get_supported_mint_units
+
+    keyset = MagicMock(active=True, unit="sat")
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(return_value=[keyset])
+    mint_url = f"http://mint-write-failure-{type(write_error).__name__}:3338"
+    with (
+        patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)),
+        patch("routstr.wallet.node_coordination.write_json", side_effect=write_error),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat"]
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [OSError("disk full"), ValueError("cache state too large")],
+    ids=["os-error", "value-error"],
+)
+@pytest.mark.asyncio
+async def test_supported_mint_unit_error_survives_cache_write_failure(
+    write_error: Exception,
+) -> None:
+    from routstr.wallet import _get_supported_mint_units
+
+    error = httpx.ConnectError("mint unavailable")
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(side_effect=error)
+    mint_url = f"http://mint-error-write-failure-{type(write_error).__name__}:3338"
+    with (
+        patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)),
+        patch("routstr.wallet.node_coordination.write_json", side_effect=write_error),
+        pytest.raises(httpx.ConnectError) as caught,
+    ):
+        await _get_supported_mint_units(mint_url)
+
+    assert caught.value is error
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [OSError("disk full"), ValueError("cache state too large")],
+    ids=["os-error", "value-error"],
+)
+@pytest.mark.asyncio
+async def test_supported_mint_units_survive_migration_write_failure(
+    write_error: Exception,
+) -> None:
+    from routstr import node_coordination
+    from routstr.wallet import _get_supported_mint_units, _mint_units_paths
+
+    mint_url = f"http://mint-migration-write-failure-{type(write_error).__name__}:3338"
+    state_path, _ = _mint_units_paths(mint_url)
+    node_coordination.write_json(
+        state_path,
+        {"version": 1, "expires_at": 10_030.0, "units": ["sat", "usd"]},
+    )
+    get_wallet = AsyncMock()
+    with (
+        patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"),
+        patch("routstr.wallet.time.monotonic", return_value=100.0),
+        patch("routstr.wallet.time.time", return_value=10_000.0),
+        patch("routstr.wallet.get_wallet", get_wallet),
+        patch("routstr.wallet.node_coordination.write_json", side_effect=write_error),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat", "usd"]
+
+    get_wallet.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_supported_units_ignore_backward_wall_step() -> None:
+    from routstr import node_coordination
+    from routstr.wallet import _get_supported_mint_units, _mint_units_paths
+
+    mint_url = "http://mint-wall-step:3338"
+    state_path, _ = _mint_units_paths(mint_url)
+    node_coordination.write_json(
+        state_path,
+        {
+            "version": 2,
+            "boot_id": "boot-a",
+            "monotonic_until": 130.0,
+            "expires_at": 10_030.0,
+            "ttl_seconds": 30.0,
+            "units": ["sat", "usd"],
+        },
+    )
+    get_wallet = AsyncMock()
+    with (
+        patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"),
+        patch("routstr.wallet.time.monotonic", return_value=110.0),
+        patch("routstr.wallet.time.time", return_value=6_400.0),
+        patch("routstr.wallet.get_wallet", get_wallet),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat", "usd"]
+
+    get_wallet.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_mint_error_expires_despite_backward_wall_step() -> None:
+    from routstr import node_coordination
+    from routstr.wallet import _get_supported_mint_units, _mint_units_paths
+
+    mint_url = "http://mint-error-wall-step:3338"
+    state_path, _ = _mint_units_paths(mint_url)
+    node_coordination.write_json(
+        state_path,
+        {
+            "version": 2,
+            "boot_id": "boot-a",
+            "monotonic_until": 130.0,
+            "expires_at": 10_030.0,
+            "ttl_seconds": 30.0,
+            "error": "old failure",
+            "error_code": "unreachable",
+        },
+    )
+    keyset = MagicMock(active=True, unit="sat")
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(return_value=[keyset])
+    with (
+        patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"),
+        patch("routstr.wallet.time.monotonic", return_value=131.0),
+        patch("routstr.wallet.time.time", return_value=6_400.0),
+        patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat"]
+
+    wallet._get_keysets.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_mint_error_fallback_is_bounded_and_migrated() -> None:
+    from routstr import node_coordination
+    from routstr.wallet import (
+        CachedMintUnitDiscoveryError,
+        _get_supported_mint_units,
+        _mint_units_paths,
+    )
+
+    mint_url = "http://legacy-mint-error:3338"
+    state_path, _ = _mint_units_paths(mint_url)
+    node_coordination.write_json(
+        state_path,
+        {
+            "version": 1,
+            "expires_at": 10_030.0,
+            "error": "old failure",
+            "error_code": "unreachable",
+        },
+    )
+    with (
+        patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"),
+        patch("routstr.wallet.time.monotonic", return_value=100.0),
+        patch("routstr.wallet.time.time", return_value=6_400.0),
+        pytest.raises(CachedMintUnitDiscoveryError, match="old failure"),
+    ):
+        await _get_supported_mint_units(mint_url)
+
+    migrated = node_coordination.read_json(state_path)
+    assert migrated is not None
+    assert migrated["version"] == 2
+    assert migrated["monotonic_until"] == 160.0
+
+    keyset = MagicMock(active=True, unit="sat")
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(return_value=[keyset])
+    with (
+        patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"),
+        patch("routstr.wallet.time.monotonic", return_value=161.0),
+        patch("routstr.wallet.time.time", return_value=6_400.0),
+        patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat"]
+
+    wallet._get_keysets.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field,value",
+    [("expires_at", float("nan")), ("monotonic_until", float("inf"))],
+)
+async def test_shared_mint_units_reject_non_finite_deadlines(
+    field: str, value: float
+) -> None:
+    from routstr import node_coordination
+    from routstr.wallet import _get_supported_mint_units, _mint_units_paths
+
+    mint_url = f"http://mint-non-finite-{field}:3338"
+    state_path, _ = _mint_units_paths(mint_url)
+    state: dict[str, object] = {
+        "version": 2,
+        "boot_id": node_coordination.NODE_BOOT_ID,
+        "monotonic_until": 130.0,
+        "expires_at": 10_030.0,
+        "ttl_seconds": 30.0,
+        "units": ["stale"],
+    }
+    state[field] = value
+    node_coordination.write_json(state_path, state)
+    keyset = MagicMock(active=True, unit="sat")
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(return_value=[keyset])
+    with (
+        patch("routstr.wallet.time.monotonic", return_value=100.0),
+        patch("routstr.wallet.time.time", return_value=10_000.0),
+        patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)),
+    ):
+        assert await _get_supported_mint_units(mint_url) == ["sat"]
+
+    wallet._get_keysets.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_supported_mint_unit_failure_is_cached() -> None:
+    from routstr.wallet import CachedMintUnitDiscoveryError, _get_supported_mint_units
+
+    wallet = MagicMock()
+    wallet._get_keysets = AsyncMock(side_effect=RuntimeError("invalid keysets"))
+    with patch("routstr.wallet.get_wallet", AsyncMock(return_value=wallet)):
+        with pytest.raises(RuntimeError, match="invalid keysets"):
+            await _get_supported_mint_units("http://mint:3338")
+        with pytest.raises(CachedMintUnitDiscoveryError, match="invalid keysets"):
+            await _get_supported_mint_units("http://mint:3338")
+
+    wallet._get_keysets.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_fetch_all_balances_backs_off_after_connection_failure() -> None:
     from routstr.core.settings import settings
@@ -162,6 +401,7 @@ async def test_fetch_all_balances_backs_off_after_connection_failure() -> None:
         patch("routstr.wallet.get_wallet", get_wallet),
         patch("routstr.wallet.db.create_session", _fake_session),
         patch("routstr.mint.time.monotonic", return_value=10),
+        patch("routstr.mint.time.time", return_value=10),
         patch("routstr.wallet.logger.warning") as warning,
     ):
         first = await fetch_all_balances(units=["sat"])
@@ -181,6 +421,7 @@ async def test_fetch_all_balances_backs_off_after_connection_failure() -> None:
         patch("routstr.wallet.get_wallet", get_wallet),
         patch("routstr.wallet.db.create_session", _fake_session),
         patch("routstr.mint.time.monotonic", return_value=71),
+        patch("routstr.mint.time.time", return_value=71),
         patch("routstr.wallet.logger.warning"),
     ):
         await fetch_all_balances(units=["sat"])
@@ -220,6 +461,7 @@ async def test_balance_failure_applies_mint_cooldown_to_other_units() -> None:
         patch("routstr.wallet.get_wallet", get_wallet),
         patch("routstr.wallet.db.create_session", _fake_session),
         patch("routstr.mint.time.monotonic", return_value=10),
+        patch("routstr.mint.time.time", return_value=10),
         patch("routstr.wallet.logger.warning") as warning,
     ):
         details, *_ = await fetch_all_balances(units=["sat", "msat"])

--- a/tests/unit/test_lightning_settlement.py
+++ b/tests/unit/test_lightning_settlement.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import httpx
 import pytest
@@ -173,6 +173,25 @@ async def test_quote_not_found_is_definitively_unpaid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unpaid_quote_poll_does_not_reload_mint_metadata() -> None:
+    _invoice_settlement_locks.clear()
+    invoice = _invoice()
+    session = AsyncMock()
+    wallet = Mock(
+        get_mint_quote=AsyncMock(
+            return_value=Mock(paid=False, state=MintQuoteState.unpaid)
+        )
+    )
+    get_wallet = AsyncMock(return_value=wallet)
+
+    with patch("routstr.lightning.get_wallet", get_wallet):
+        assert await check_invoice_payment(invoice, session) is True  # type: ignore[arg-type]
+
+    get_wallet.assert_awaited_once_with("http://mint:3338", "sat", load=False)
+    wallet.get_mint_quote.assert_awaited_once_with("quote-1")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "message",
     [
@@ -291,8 +310,9 @@ async def test_ambiguous_invoice_mint_timeout_remains_recoverable() -> None:
     async def owned_session() -> AsyncIterator[AsyncMock]:
         yield state_session
 
+    get_wallet = AsyncMock(return_value=wallet)
     with (
-        patch("routstr.lightning.get_wallet", AsyncMock(return_value=wallet)),
+        patch("routstr.lightning.get_wallet", get_wallet),
         patch("routstr.lightning.create_session", owned_session),
         patch(
             "routstr.lightning._mint_invoice_quote",
@@ -307,6 +327,10 @@ async def test_ambiguous_invoice_mint_timeout_remains_recoverable() -> None:
     session.rollback.assert_not_awaited()
     # One commit closes the initial read transaction before external I/O.
     session.commit.assert_awaited_once()
+    assert get_wallet.await_args_list == [
+        call("http://mint:3338", "sat", load=False),
+        call("http://mint:3338", "sat"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -327,9 +351,7 @@ async def test_quote_not_found_after_payment_confirmation_is_not_unpaid() -> Non
         patch("routstr.lightning.create_session", owned_session),
         patch(
             "routstr.lightning._mint_invoice_quote",
-            AsyncMock(
-                side_effect=Exception("Mint Error: quote not found (Code: 0)")
-            ),
+            AsyncMock(side_effect=Exception("Mint Error: quote not found (Code: 0)")),
         ),
         patch("routstr.lightning._reload_invoice_view", AsyncMock()),
     ):
@@ -423,7 +445,8 @@ async def test_recover_applies_authoritative_expiry_helper() -> None:
         ) as expire_invoice,
     ):
         response = await recover_invoice(
-            InvoiceRecoverRequest(bolt11="lnbc-test"), session  # type: ignore[arg-type]
+            InvoiceRecoverRequest(bolt11="lnbc-test"),
+            session,  # type: ignore[arg-type]
         )
 
     assert response.status == "expired"
@@ -454,7 +477,8 @@ async def test_paid_state_write_failure_still_reports_non_expirable_outcome() ->
         patch("routstr.lightning._reload_invoice_view", AsyncMock()),
     ):
         definitively_unpaid = await check_invoice_payment(
-            invoice, session  # type: ignore[arg-type]
+            invoice,
+            session,  # type: ignore[arg-type]
         )
 
     assert definitively_unpaid is False
@@ -470,7 +494,8 @@ async def test_settlement_pending_invoice_does_not_expire() -> None:
 
     with patch("routstr.lightning.check_invoice_payment", check):
         response = await get_invoice_status(
-            invoice.id, session  # type: ignore[arg-type]
+            invoice.id,
+            session,  # type: ignore[arg-type]
         )
 
     check.assert_awaited_once_with(invoice, session)
@@ -561,7 +586,8 @@ async def test_recovery_reaches_the_mint_for_an_invoice_past_grace() -> None:
 
     with patch("routstr.lightning.check_invoice_payment", check):
         response = await recover_invoice(
-            InvoiceRecoverRequest(bolt11="lnbc-test"), session  # type: ignore[arg-type]
+            InvoiceRecoverRequest(bolt11="lnbc-test"),
+            session,  # type: ignore[arg-type]
         )
 
     check.assert_awaited_once()

--- a/tests/unit/test_mint.py
+++ b/tests/unit/test_mint.py
@@ -1,10 +1,12 @@
 import asyncio
+import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 from cashu.core.base import Unit
 
+from routstr import node_coordination
 from routstr.mint import (
     MintCooldownError,
     MintRateGuard,
@@ -103,19 +105,238 @@ async def test_cashu_429_dispatches_through_wallet_override() -> None:
         await wallet.mint_quote(1, Unit.sat)
 
 
-async def test_guard_concurrency_change_preserves_cooldown_state() -> None:
+@pytest.mark.asyncio
+async def test_cancelled_probe_releases_node_lock() -> None:
+    mint_url = "https://mint.test-cancelled-probe"
+    guard = MintRateGuard(mint_url, max_concurrency=1)
+    guard.apply_cooldown(0, reason="rate_limited")
+    started = asyncio.Event()
+
+    async def blocked() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(guard.run(blocked))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    operation = AsyncMock(return_value="recovered")
+    assert await MintRateGuard(mint_url, 1).run(operation) == "recovered"
+    operation.assert_awaited_once()
+
+
+def test_corrupt_shared_state_fails_open() -> None:
+    guard = MintRateGuard("https://mint.test-corrupt-state", max_concurrency=1)
+    guard._state_path.parent.mkdir(parents=True, exist_ok=True)
+    guard._state_path.write_text("not-json")
+
+    assert guard.cooldown_remaining() == 0
+
+
+@pytest.mark.parametrize("wall_step", [3600.0, -3600.0])
+def test_shared_cooldown_ignores_wall_clock_steps(wall_step: float) -> None:
+    clock = {"wall": 10_000.0, "monotonic": 100.0}
+    mint_url = f"https://mint.test-wall-step-{wall_step}"
+
+    with (
+        patch("routstr.mint._NODE_BOOT_ID", "boot-a"),
+        patch("routstr.mint.time.time", side_effect=lambda: clock["wall"]),
+        patch(
+            "routstr.mint.time.monotonic",
+            side_effect=lambda: clock["monotonic"],
+        ),
+    ):
+        MintRateGuard(mint_url, 1).apply_cooldown(60, reason="rate_limited")
+        clock["wall"] += 10 + wall_step
+        clock["monotonic"] += 10
+
+        fresh = MintRateGuard(mint_url, 1)
+        assert fresh.cooldown_remaining() == pytest.approx(50)
+        assert fresh.cooldown_reason() == "rate_limited"
+
+
+def test_backward_wall_step_does_not_reject_maximum_cooldown() -> None:
+    clock = {"wall": 10_000.0, "monotonic": 100.0}
+    mint_url = "https://mint.test-wall-validation"
+    maximum = 7 * 60 * 60
+
+    with (
+        patch("routstr.mint._NODE_BOOT_ID", "boot-a"),
+        patch("routstr.mint.time.time", side_effect=lambda: clock["wall"]),
+        patch(
+            "routstr.mint.time.monotonic",
+            side_effect=lambda: clock["monotonic"],
+        ),
+    ):
+        MintRateGuard(mint_url, 1).apply_cooldown(maximum, reason="rate_limited")
+        clock["wall"] -= 120
+        clock["monotonic"] += 1
+
+        fresh = MintRateGuard(mint_url, 1)
+        assert fresh.cooldown_remaining() == pytest.approx(maximum - 1)
+
+
+def test_shared_cooldown_falls_back_to_wall_clock_after_reboot() -> None:
+    clock = {"wall": 10_000.0, "monotonic": 100.0}
+    mint_url = "https://mint.test-reboot-fallback"
+
+    with (
+        patch("routstr.mint._NODE_BOOT_ID", "boot-a"),
+        patch("routstr.mint.time.time", side_effect=lambda: clock["wall"]),
+        patch(
+            "routstr.mint.time.monotonic",
+            side_effect=lambda: clock["monotonic"],
+        ),
+    ):
+        MintRateGuard(mint_url, 1).apply_cooldown(60, reason="transport")
+
+    clock = {"wall": 10_010.0, "monotonic": 5.0}
+    with (
+        patch("routstr.mint._NODE_BOOT_ID", "boot-b"),
+        patch("routstr.mint.time.time", side_effect=lambda: clock["wall"]),
+        patch(
+            "routstr.mint.time.monotonic",
+            side_effect=lambda: clock["monotonic"],
+        ),
+    ):
+        fresh = MintRateGuard(mint_url, 1)
+        assert fresh.cooldown_remaining() == pytest.approx(50)
+        assert fresh.cooldown_reason() == "transport"
+
+
+def test_legacy_shared_cooldown_uses_bounded_wall_clock_fallback() -> None:
+    guard = MintRateGuard("https://mint.test-legacy-state", 1)
+    node_coordination.write_json(
+        guard._state_path,
+        {
+            "version": 2,
+            "cooldown_until": time.time() + 30,
+            "reason": "transport",
+            "consecutive_rate_limits": 0,
+            "needs_probe": True,
+            "generation": 4,
+        },
+    )
+
+    assert guard.cooldown_remaining() == pytest.approx(30, abs=1)
+    assert guard._needs_probe is True
+
+
+async def test_guard_concurrency_change_uses_current_shared_state() -> None:
     from routstr.core.settings import settings
 
     mint_url = "https://mint.test-concurrency-carryover"
     with patch.object(settings, "mint_max_concurrency", 2):
-        guard = MintRateGuard.get(mint_url)
-        guard.apply_cooldown(120.0, reason="rate_limited")
-        guard._consecutive_rate_limits = 3
+        stale = MintRateGuard.get(mint_url)
+        stale.apply_rate_limit_cooldown()
+        stale._consecutive_rate_limits = 7
+
+    current = MintRateGuard(mint_url, 2)
+    state = current._read_shared_state()
+    assert state is not None
+    assert current._clear_shared_state(state[4])
 
     with patch.object(settings, "mint_max_concurrency", 5):
         rebuilt = MintRateGuard.get(mint_url)
 
-    assert rebuilt is not guard
-    assert rebuilt.cooldown_remaining() > 0
-    assert rebuilt._cooldown_reason == "rate_limited"
-    assert rebuilt._consecutive_rate_limits == 3
+    assert rebuilt is not stale
+    assert rebuilt.cooldown_remaining() == 0
+    assert rebuilt._needs_probe is False
+    assert rebuilt._consecutive_rate_limits == 0
+
+
+async def test_delayed_waiter_does_not_restore_cleared_probe_state() -> None:
+    mint_url = "https://mint.test-delayed-waiter"
+    guard = MintRateGuard(mint_url, 1)
+    guard.apply_cooldown(60, reason="rate_limited")
+
+    async def clear_while_waiting(_: float) -> None:
+        other = MintRateGuard(mint_url, 1)
+        state = other._read_shared_state()
+        assert state is not None
+        assert other._clear_shared_state(state[4])
+
+    with patch("routstr.mint.asyncio.sleep", clear_while_waiting):
+        await guard._wait_for_cooldown()
+
+    state = guard._read_shared_state()
+    assert state is not None
+    assert state[3] is False
+
+
+async def test_waiter_does_not_restore_state_cleared_between_reads() -> None:
+    mint_url = "https://mint.test-waiter-cleared-between-reads"
+    guard = MintRateGuard(mint_url, 1)
+    guard.apply_cooldown(60, reason="rate_limited")
+    read_shared_state = guard._read_shared_state
+    read_calls = 0
+    state_cleared = False
+
+    def read_and_clear_after_second_snapshot():
+        nonlocal read_calls, state_cleared
+        read_calls += 1
+        state = read_shared_state()
+        if read_calls == 2:
+            other = MintRateGuard(mint_url, 1)
+            current = other._read_shared_state()
+            assert current is not None
+            assert other._clear_shared_state(current[4])
+            state_cleared = True
+        return state
+
+    with (
+        patch.object(guard, "_read_shared_state", read_and_clear_after_second_snapshot),
+        patch("routstr.mint.asyncio.sleep", new=AsyncMock()),
+    ):
+        await guard._wait_for_cooldown()
+
+    state = read_shared_state()
+    assert state_cleared
+    assert state is not None
+    assert state[3] is False
+
+
+async def test_waiter_does_not_clear_extended_cooldown() -> None:
+    mint_url = "https://mint.test-waiter-extension"
+    guard = MintRateGuard(mint_url, 1)
+    guard.apply_cooldown(10, reason="rate_limited")
+    sleep_calls = 0
+
+    async def extend_then_stop(_: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            MintRateGuard(mint_url, 1).apply_cooldown(60, reason="transport")
+        else:
+            raise asyncio.CancelledError
+
+    with (
+        patch("routstr.mint.asyncio.sleep", side_effect=extend_then_stop),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await guard._wait_for_cooldown()
+
+    state = guard._read_shared_state()
+    assert state is not None
+    assert state[0] > time.monotonic()
+    assert state[1] == "transport"
+    assert state[3] is True
+
+
+async def test_successful_probe_keeps_newer_cooldown() -> None:
+    mint_url = "https://mint.test-probe-generation"
+    guard = MintRateGuard(mint_url, 1)
+    guard.apply_cooldown(0, reason="rate_limited")
+
+    async def probe() -> str:
+        MintRateGuard(mint_url, 1).apply_cooldown(60, reason="transport")
+        return "ok"
+
+    assert await guard.run(probe) == "ok"
+    state = guard._read_shared_state()
+    assert state is not None
+    assert state[0] > 0
+    assert state[1] == "transport"
+    assert state[3] is True

--- a/tests/unit/test_mint_cross_process.py
+++ b/tests/unit/test_mint_cross_process.py
@@ -1,0 +1,175 @@
+import asyncio
+import fcntl
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+from routstr import node_coordination
+from routstr.mint import MintRateGuard
+
+
+def _configure(root: str) -> None:
+    node_coordination.NODE_STATE_DIR = Path(root)
+    MintRateGuard._guards.clear()
+
+
+def _read_counter(path: Path) -> dict[str, int]:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"active": 0, "peak": 0, "calls": 0}
+
+
+def _cooldown_reader(root: str, queue: multiprocessing.Queue) -> None:  # type: ignore[type-arg]
+    _configure(root)
+    queue.put(MintRateGuard("https://mint.test", 1).cooldown_remaining())
+
+
+def _probe_worker(
+    root: str, counter_path: str, release_path: str, queue: multiprocessing.Queue
+) -> None:  # type: ignore[type-arg]
+    _configure(root)
+
+    async def run() -> None:
+        async def operation() -> str:
+            path = Path(counter_path)
+            lock_path = path.with_suffix(".lock")
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                value = _read_counter(path)
+                value["calls"] += 1
+                path.write_text(json.dumps(value))
+                first = value["calls"] == 1
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+            if first:
+                while not Path(release_path).exists():
+                    await asyncio.sleep(0.01)
+            return "ok"
+
+        result = await MintRateGuard("https://mint.test", 2).run(operation)
+        queue.put(result)
+
+    try:
+        asyncio.run(run())
+    except BaseException as error:
+        queue.put(f"error:{error!r}")
+
+
+def _slot_worker(root: str, counter_path: str, queue: multiprocessing.Queue) -> None:  # type: ignore[type-arg]
+    _configure(root)
+
+    async def run() -> None:
+        path = Path(counter_path)
+
+        async def operation() -> None:
+            lock_path = path.with_suffix(".lock")
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                value = _read_counter(path)
+                active = value["active"] + 1
+                value.update(active=active, peak=max(value["peak"], active))
+                path.write_text(json.dumps(value))
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+            await asyncio.sleep(0.2)
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                value = _read_counter(path)
+                value["active"] -= 1
+                path.write_text(json.dumps(value))
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+
+        await MintRateGuard("https://mint.test", 2).run(operation)
+        queue.put("ok")
+
+    try:
+        asyncio.run(run())
+    except BaseException as error:
+        queue.put(f"error:{error!r}")
+
+
+def _join(processes: list[multiprocessing.Process]) -> None:
+    try:
+        for process in processes:
+            process.join(timeout=10)
+            assert process.exitcode == 0
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        for process in processes:
+            process.join(timeout=5)
+
+
+def test_cooldown_is_visible_across_processes(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    _configure(str(root))
+    MintRateGuard("https://mint.test", 1).apply_cooldown(10, reason="rate_limited")
+    context = multiprocessing.get_context("fork")
+    queue = context.Queue()
+    process = context.Process(target=_cooldown_reader, args=(str(root), queue))
+    process.start()
+    _join([process])
+
+    assert queue.get(timeout=1) > 0
+
+
+def test_one_recovery_probe_runs_across_processes(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    counter = tmp_path / "probe-counter.json"
+    release = tmp_path / "release"
+    counter.write_text(json.dumps({"active": 0, "peak": 0, "calls": 0}))
+    _configure(str(root))
+    MintRateGuard("https://mint.test", 2).apply_cooldown(0, reason="rate_limited")
+    context = multiprocessing.get_context("fork")
+    queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_probe_worker,
+            args=(str(root), str(counter), str(release), queue),
+        )
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+
+    try:
+        deadline = time.time() + 5
+        while _read_counter(counter)["calls"] < 1 and time.time() < deadline:
+            time.sleep(0.01)
+        time.sleep(0.2)
+        assert _read_counter(counter)["calls"] == 1
+    finally:
+        release.touch()
+        _join(processes)
+
+    assert sorted(queue.get(timeout=1) for _ in processes) == ["ok", "ok"]
+    assert _read_counter(counter)["calls"] == 2
+
+
+def test_node_concurrency_slots_bound_all_processes(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    counter = tmp_path / "slot-counter.json"
+    counter.write_text(json.dumps({"active": 0, "peak": 0, "calls": 0}))
+    context = multiprocessing.get_context("fork")
+    queue = context.Queue()
+    processes = [
+        context.Process(target=_slot_worker, args=(str(root), str(counter), queue))
+        for _ in range(4)
+    ]
+    for process in processes:
+        process.start()
+    _join(processes)
+
+    assert [queue.get(timeout=1) for _ in processes] == ["ok"] * 4
+    assert _read_counter(counter)["peak"] == 2

--- a/tests/unit/test_node_coordination.py
+++ b/tests/unit/test_node_coordination.py
@@ -1,0 +1,61 @@
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from routstr import node_coordination
+
+
+def _assert_read_json_returns_none(path: Path) -> None:
+    assert node_coordination.read_json(path) is None
+
+
+def test_read_json_rejects_oversized_state(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_bytes(b"{" + b'"x":"' + b"a" * node_coordination._MAX_STATE_BYTES)
+
+    assert node_coordination.read_json(path) is None
+
+
+def test_read_json_rejects_deeply_nested_state(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text("[" * 1100 + "0" + "]" * 1100)
+
+    assert node_coordination.read_json(path) is None
+
+
+def test_read_json_rejects_oversized_integer(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text('{"value":' + "9" * 4000 + "}")
+
+    assert node_coordination.read_json(path) is None
+
+
+def test_read_json_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text('{"value":1}')
+    link = tmp_path / "state.json"
+    os.symlink(target, link)
+
+    assert node_coordination.read_json(link) is None
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo") or not hasattr(os, "O_NONBLOCK"),
+    reason="FIFO non-blocking reads are unavailable",
+)
+def test_read_json_rejects_fifo_without_blocking(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    os.mkfifo(path)
+    process = multiprocessing.Process(
+        target=_assert_read_json_returns_none, args=(path,)
+    )
+    process.start()
+    process.join(timeout=2)
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        pytest.fail("read_json blocked while opening a FIFO")
+
+    assert process.exitcode == 0

--- a/tests/unit/test_redemption_negative_cache.py
+++ b/tests/unit/test_redemption_negative_cache.py
@@ -1,13 +1,15 @@
-"""Unit tests for the terminal-redemption negative cache."""
+"""Unit tests for the redemption failure cache."""
 
+from pathlib import Path
 from typing import Iterator
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from routstr.auth import (
     _cached_failure_to_http_exception,
-    _maybe_cache_terminal_redemption_failure,
+    _maybe_cache_redemption_failure,
 )
 from routstr.redemption_cache import (
     TERMINAL_REDEMPTION_CODES,
@@ -21,6 +23,12 @@ FAILURE = CachedRedemptionFailure(
     error_type="token_already_spent",
     message="Cashu token already spent",
     code="cashu_token_already_spent",
+)
+TRANSIENT_FAILURE = CachedRedemptionFailure(
+    status_code=503,
+    error_type="mint_unreachable",
+    message="Cashu mint unavailable",
+    code="cashu_mint_unreachable",
 )
 
 
@@ -92,10 +100,155 @@ class TestRedemptionNegativeCache:
         with pytest.raises(ValueError):
             RedemptionNegativeCache(ttl_seconds=0)
 
+    def test_file_tier_is_visible_to_another_worker(self, tmp_path: Path) -> None:
+        key = "a" * 64
+        first = RedemptionNegativeCache(storage_dir=tmp_path)
+        second = RedemptionNegativeCache(storage_dir=tmp_path)
 
-class TestMaybeCacheTerminalRedemptionFailure:
+        first.put(key, FAILURE)
+
+        assert second.get(key) == FAILURE
+        assert (tmp_path / key).stat().st_mode & 0o777 == 0o600
+
+    def test_file_tier_expires_and_removes_entry(self, tmp_path: Path) -> None:
+        clock = FakeClock()
+        key = "b" * 64
+        first = RedemptionNegativeCache(
+            storage_dir=tmp_path, clock=clock, wall_clock=clock
+        )
+        second = RedemptionNegativeCache(
+            storage_dir=tmp_path, clock=clock, wall_clock=clock
+        )
+        first.put(key, FAILURE, ttl_seconds=10)
+        clock.now = 10
+
+        assert second.get(key) is None
+        assert not (tmp_path / key).exists()
+
+    def test_corrupt_file_is_ignored_and_removed(self, tmp_path: Path) -> None:
+        key = "c" * 64
+        tmp_path.mkdir(exist_ok=True)
+        (tmp_path / key).write_text("not-json")
+        cache = RedemptionNegativeCache(storage_dir=tmp_path)
+
+        assert cache.get(key) is None
+        assert not (tmp_path / key).exists()
+
+    def test_transient_ttl_is_clamped_to_contract_maximum(self) -> None:
+        clock = FakeClock()
+        cache = RedemptionNegativeCache(clock=clock, wall_clock=clock)
+        cache.put("deadbeef", TRANSIENT_FAILURE, ttl_seconds=3_600)
+
+        clock.now = 60
+        assert cache.get("deadbeef") is None
+
+    def test_shared_transient_ttl_ignores_backward_wall_step(
+        self, tmp_path: Path
+    ) -> None:
+        monotonic = FakeClock()
+        monotonic.now = 100
+        wall = FakeClock()
+        wall.now = 10_000
+        key = "d" * 64
+        first = RedemptionNegativeCache(
+            storage_dir=tmp_path, clock=monotonic, wall_clock=wall
+        )
+        first.put(key, TRANSIENT_FAILURE, ttl_seconds=30)
+
+        wall.now = 6_400
+        monotonic.now = 110
+        second = RedemptionNegativeCache(
+            storage_dir=tmp_path, clock=monotonic, wall_clock=wall
+        )
+        assert second.get(key) == TRANSIENT_FAILURE
+        monotonic.now = 130
+        assert second.get(key) is None
+
+    def test_legacy_transient_ttl_is_bounded_after_backward_wall_step(
+        self, tmp_path: Path
+    ) -> None:
+        from routstr import node_coordination
+
+        clock = FakeClock()
+        clock.now = 6_400
+        key = "e" * 64
+        node_coordination.write_json(
+            tmp_path / key,
+            {
+                "version": 1,
+                "expires_at": 10_030,
+                "status_code": TRANSIENT_FAILURE.status_code,
+                "error_type": TRANSIENT_FAILURE.error_type,
+                "message": TRANSIENT_FAILURE.message,
+                "code": TRANSIENT_FAILURE.code,
+            },
+        )
+        cache = RedemptionNegativeCache(
+            storage_dir=tmp_path, clock=clock, wall_clock=clock
+        )
+
+        with patch("routstr.node_coordination.NODE_BOOT_ID", "boot-a"):
+            assert cache.get(key) == TRANSIENT_FAILURE
+            clock.now += 61
+            assert cache.get(key) is None
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [("expires_at", float("nan")), ("monotonic_until", float("inf"))],
+    )
+    def test_shared_non_finite_deadline_is_rejected(
+        self, tmp_path: Path, field: str, value: float
+    ) -> None:
+        from routstr import node_coordination
+
+        key = "f" * 64
+        state: dict[str, object] = {
+            "version": 2,
+            "boot_id": node_coordination.NODE_BOOT_ID,
+            "monotonic_until": 30.0,
+            "expires_at": 30.0,
+            "ttl_seconds": 30.0,
+            "status_code": TRANSIENT_FAILURE.status_code,
+            "error_type": TRANSIENT_FAILURE.error_type,
+            "message": TRANSIENT_FAILURE.message,
+            "code": TRANSIENT_FAILURE.code,
+        }
+        state[field] = value
+        node_coordination.write_json(tmp_path / key, state)
+
+        assert RedemptionNegativeCache(storage_dir=tmp_path).get(key) is None
+        assert not (tmp_path / key).exists()
+
+    def test_shared_write_failure_keeps_memory_entry(self, tmp_path: Path) -> None:
+        key = "d" * 64
+        cache = RedemptionNegativeCache(storage_dir=tmp_path)
+
+        with patch(
+            "routstr.redemption_cache.node_coordination.write_json",
+            side_effect=OSError("disk unavailable"),
+        ):
+            cache.put(key, FAILURE)
+
+        assert cache.get(key) == FAILURE
+
+    def test_trim_ignores_file_removed_during_stat(self, tmp_path: Path) -> None:
+        cache = RedemptionNegativeCache(max_entries=1, storage_dir=tmp_path)
+        missing = MagicMock()
+        missing.is_file.return_value = True
+        missing.stat.side_effect = FileNotFoundError
+        present = MagicMock()
+        present.is_file.return_value = True
+        present.stat.return_value.st_mtime = 1.0
+
+        with patch(
+            "routstr.redemption_cache.os.scandir", return_value=[missing, present]
+        ):
+            cache._trim_shared()
+
+
+class TestMaybeCacheRedemptionFailure:
     def test_already_spent_error_is_cached(self) -> None:
-        _maybe_cache_terminal_redemption_failure(
+        _maybe_cache_redemption_failure(
             "deadbeef", Exception("Mint Error: Token already spent. (Code: 11001)")
         )
         cached = redemption_negative_cache.get("deadbeef")
@@ -103,24 +256,25 @@ class TestMaybeCacheTerminalRedemptionFailure:
         assert cached.code == "cashu_token_already_spent"
         assert cached.status_code == 400
 
-    def test_transient_mint_unreachable_is_not_cached(self) -> None:
+    def test_transient_mint_unreachable_is_cached_briefly(self) -> None:
         import httpx
 
-        _maybe_cache_terminal_redemption_failure(
+        _maybe_cache_redemption_failure(
             "deadbeef", httpx.ConnectError("connection refused")
         )
-        assert redemption_negative_cache.get("deadbeef") is None
+        cached = redemption_negative_cache.get("deadbeef")
+        assert cached is not None
+        assert cached.code == "cashu_mint_unreachable"
+        assert cached.status_code == 503
 
     def test_unclassified_error_is_not_cached(self) -> None:
-        _maybe_cache_terminal_redemption_failure(
-            "deadbeef", RuntimeError("some internal fault")
-        )
+        _maybe_cache_redemption_failure("deadbeef", RuntimeError("some internal fault"))
         assert redemption_negative_cache.get("deadbeef") is None
 
     def test_generic_value_error_is_not_cached(self) -> None:
-        # cashu_token_redemption_failed is deliberately NOT terminal — a
-        # generic ValueError can wrap transient faults.
-        _maybe_cache_terminal_redemption_failure(
+        # The generic code is deliberately not cached because a ValueError may
+        # wrap a transient fault.
+        _maybe_cache_redemption_failure(
             "deadbeef", ValueError("something went wrong during redemption")
         )
         assert redemption_negative_cache.get("deadbeef") is None

--- a/tests/unit/test_wallet.py
+++ b/tests/unit/test_wallet.py
@@ -80,6 +80,51 @@ async def test_get_wallet_force_reload_bypasses_reload_interval() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_wallet_uses_node_shared_metadata_refresh() -> None:
+    from routstr import wallet as wallet_module
+    from routstr.wallet import get_wallet
+
+    first = Mock(load_mint=AsyncMock(), load_proofs=AsyncMock(), keysets={"a": Mock()})
+    second = Mock(
+        load_mint=AsyncMock(),
+        load_proofs=AsyncMock(),
+        activate_keyset=AsyncMock(),
+        keysets={"a": Mock()},
+    )
+    with patch("routstr.wallet.Wallet.with_db", AsyncMock(side_effect=[first, second])):
+        await get_wallet("http://mint:3338", "sat")
+        wallet_module._wallets.clear()
+        wallet_module._wallet_last_load.clear()
+        wallet_module._wallet_load_locks.clear()
+        await get_wallet("http://mint:3338", "sat")
+
+    first.load_mint.assert_awaited_once()
+    second.load_mint.assert_not_awaited()
+    second.load_proofs.assert_awaited_once_with(reload=True)
+    second.activate_keyset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forced_reload_is_deduplicated_inside_wallet_operation() -> None:
+    from routstr.wallet import get_wallet, wallet_operation_guard
+
+    wallet = Mock(
+        load_mint=AsyncMock(),
+        load_proofs=AsyncMock(),
+        activate_keyset=AsyncMock(),
+        keysets={"a": Mock()},
+    )
+    with patch("routstr.wallet.Wallet.with_db", AsyncMock(return_value=wallet)):
+        async with wallet_operation_guard():
+            await get_wallet("http://mint:3338", "sat", force_reload=True)
+            await get_wallet("http://mint:3338", "sat", force_reload=True)
+
+    wallet.load_mint.assert_awaited_once()
+    assert wallet.load_proofs.await_count == 2
+    wallet.activate_keyset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_public_recieve_token_holds_wallet_operation_guard() -> None:
     inside_guard = False
 
@@ -2099,9 +2144,11 @@ async def test_mint_rate_guard_exponentially_backs_off_repeated_429s() -> None:
     expected_delays = [60, 120, 240, 480, 960, 1920, 3840, 7680, 15360, 25200]
     now = 0.0
 
-    with patch("routstr.mint.time.monotonic") as monotonic:
+    with (
+        patch("routstr.mint.time.monotonic", side_effect=lambda: now),
+        patch("routstr.mint.time.time", side_effect=lambda: now),
+    ):
         for index, expected in enumerate(expected_delays, start=1):
-            monotonic.return_value = now
             assert guard.apply_rate_limit_cooldown(60) == expected
             assert guard._consecutive_rate_limits == index
             if index == 1:
@@ -2111,7 +2158,6 @@ async def test_mint_rate_guard_exponentially_backs_off_repeated_429s() -> None:
                 assert guard._consecutive_rate_limits == 1
             now += expected + 1
 
-        monotonic.return_value = now
         operation = AsyncMock(return_value="ok")
         assert await guard.run(operation) == "ok"
         assert guard._consecutive_rate_limits == 0
@@ -2168,16 +2214,24 @@ async def test_mint_rate_guard_keeps_cooldown_when_concurrency_is_unlimited() ->
     from routstr.wallet import _MintRateGuard
 
     operation = AsyncMock(return_value="ok")
+    now = 0.0
+
+    async def advance(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
     with (
         patch.object(settings, "mint_max_concurrency", 0),
-        patch("routstr.mint.time.monotonic", return_value=0),
-        patch("routstr.mint.asyncio.sleep", AsyncMock()) as sleep,
+        patch("routstr.mint.time.monotonic", side_effect=lambda: now),
+        patch("routstr.mint.time.time", side_effect=lambda: now),
+        patch("routstr.mint.asyncio.sleep", AsyncMock(side_effect=advance)) as sleep,
     ):
         guard = _MintRateGuard.get("http://mint:3338")
         guard.apply_cooldown(5)
         assert await guard.run(operation) == "ok"
 
-    sleep.assert_awaited_once_with(5)
+    sleep.assert_awaited_once()
+    assert sleep.await_args.args[0] == pytest.approx(5, abs=0.1)
     operation.assert_awaited_once()
 
 
@@ -2199,18 +2253,26 @@ async def test_mint_operation_honors_retry_after_as_minimum() -> None:
             )
         return "ok"
 
-    sleep = AsyncMock()
+    now = 0.1
+
+    async def advance(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    sleep = AsyncMock(side_effect=advance)
     with patch.object(settings, "mint_retry_max_attempts", 1):
         with patch.object(settings, "mint_operation_timeout_seconds", 0):
             with patch.object(settings, "mint_max_concurrency", 1):
-                with patch("routstr.mint.time.monotonic", return_value=0.1):
-                    with patch("routstr.mint.asyncio.sleep", sleep):
-                        result = await _mint_operation(
-                            factory, mint_url="http://mint:3338"
-                        )
+                with (
+                    patch("routstr.mint.time.monotonic", side_effect=lambda: now),
+                    patch("routstr.mint.time.time", side_effect=lambda: now),
+                    patch("routstr.mint.asyncio.sleep", sleep),
+                ):
+                    result = await _mint_operation(factory, mint_url="http://mint:3338")
 
     assert result == "ok"
-    sleep.assert_awaited_once_with(60.0)
+    sleep.assert_awaited_once()
+    assert sleep.await_args.args[0] == pytest.approx(60.0, abs=0.1)
 
 
 @pytest.mark.asyncio
@@ -2219,10 +2281,18 @@ async def test_mint_operation_timeout_excludes_adaptive_cooldown() -> None:
     from routstr.wallet import _mint_operation, _MintRateGuard
 
     operation = AsyncMock(return_value="ok")
+    now = 0.0
+
+    async def advance(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
     with (
         patch.object(settings, "mint_max_concurrency", 1),
         patch.object(settings, "mint_operation_timeout_seconds", 0.01),
-        patch("routstr.mint.asyncio.sleep", AsyncMock()) as sleep,
+        patch("routstr.mint.time.monotonic", side_effect=lambda: now),
+        patch("routstr.mint.time.time", side_effect=lambda: now),
+        patch("routstr.mint.asyncio.sleep", AsyncMock(side_effect=advance)) as sleep,
     ):
         guard = _MintRateGuard.get("http://mint:3338")
         guard.apply_cooldown(60)
@@ -2245,11 +2315,19 @@ async def test_default_timeout_allows_retry_after_rate_limit_cooldown() -> None:
             "ok",
         ]
     )
+    now = 0.0
+
+    async def advance(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
     with (
         patch.object(settings, "mint_retry_max_attempts", 3),
         patch.object(settings, "mint_operation_timeout_seconds", 30),
         patch.object(settings, "mint_max_concurrency", 1),
-        patch("routstr.mint.asyncio.sleep", AsyncMock()),
+        patch("routstr.mint.time.monotonic", side_effect=lambda: now),
+        patch("routstr.mint.time.time", side_effect=lambda: now),
+        patch("routstr.mint.asyncio.sleep", AsyncMock(side_effect=advance)),
     ):
         assert await _mint_operation(operation, mint_url="http://mint:3338") == "ok"
 


### PR DESCRIPTION
## Summary

- coordinate mint cooldowns, recovery probes, concurrency slots, redemption failures, and wallet cache state across worker processes
- persist auto-top-up reservations before upstream handoff and add a guarded admin recovery flow for ambiguous Routstr top-ups
- make shared state bounded, atomic, clock-step-safe, and fail-open when cache persistence is unavailable
- harden Lightning settlement and wallet refresh interactions around concurrent mint operations
- add unit, integration, and real multiprocess coverage for races, cancellation, cache failures, clock changes, and recovery fencing
