### PR TITLE
feat(payment): record whether each cache rate was configured or inferred

### DIFF
--- a/routstr/payment/cost_calculation.py
+++ b/routstr/payment/cost_calculation.py
@@ -1,5 +1,5 @@
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from pydantic.v1 import BaseModel
 
@@ -46,6 +46,20 @@ class MaxCostData(CostData):
 class CostDataError(BaseModel):
     message: str
     code: str
+
+
+class PricingRates(NamedTuple):
+    """Per-1k-token rates for the four billable token categories.
+
+    The four arrived as a bare tuple, unpacked positionally at two call sites.
+    Two of them are cache rates that routinely fall back to the prompt rate,
+    which makes a transposition read as a plausible bill rather than a crash.
+    """
+
+    input_1k: float
+    output_1k: float
+    cache_read_1k: float
+    cache_write_1k: float
 
 
 def _empty_cost(cls: type[CostData] = CostData) -> CostData:
@@ -187,7 +201,7 @@ async def calculate_cost(
             output_usd = _coerce_usd(cost_details.get("output_cost")) or _coerce_usd(
                 cost_details.get("upstream_inference_completions_cost")
             )
-            cache_pricing_rates: tuple[float, float, float, float] | None = None
+            cache_pricing_rates: PricingRates | None = None
             if cache_read_tokens > 0 or cache_creation_tokens > 0:
                 try:
                     cache_pricing_rates = _get_pricing_rates(
@@ -203,11 +217,11 @@ async def calculate_cost(
                     fixed_input_rate = (
                         float(settings.fixed_per_1k_input_tokens) * 1000.0
                     )
-                    cache_pricing_rates = (
-                        fixed_input_rate,
-                        float(settings.fixed_per_1k_output_tokens) * 1000.0,
-                        fixed_input_rate,
-                        fixed_input_rate,
+                    cache_pricing_rates = PricingRates(
+                        input_1k=fixed_input_rate,
+                        output_1k=float(settings.fixed_per_1k_output_tokens) * 1000.0,
+                        cache_read_1k=fixed_input_rate,
+                        cache_write_1k=fixed_input_rate,
                     )
             return _calculate_from_usd_cost(
                 usd_cost,
@@ -243,7 +257,10 @@ async def calculate_cost(
         cache_read_rate = input_rate
         cache_creation_rate = input_rate
     else:
-        input_rate, output_rate, cache_read_rate, cache_creation_rate = pricing_rates
+        input_rate = pricing_rates.input_1k
+        output_rate = pricing_rates.output_1k
+        cache_read_rate = pricing_rates.cache_read_1k
+        cache_creation_rate = pricing_rates.cache_write_1k
 
     # Truthiness is not the question: `NaN` and a negative rate are both truthy
     # and sailed past this gate into the token math, while a rate of zero is a
@@ -365,14 +382,13 @@ def _get_pricing_rates(
     response_data: dict,
     model_obj: "Model | None",
     provider_fee: float | None,
-) -> tuple[float, float, float, float] | None:
+) -> PricingRates | None:
     """Get configured rates, falling back to LiteLLM's model cost map.
 
     The served ``model_obj`` (when the caller has it) is billed directly;
     otherwise the response's model string is resolved through the alias map,
     which yields the best-ranked candidate rather than the serving one.
 
-    Returns: (input_rate, output_rate, cache_read_rate, cache_write_rate).
     ``None`` means configured fixed pricing should be used by the caller.
     """
     if settings.fixed_pricing and (
@@ -457,7 +473,12 @@ def _get_pricing_rates(
             "cache_write_price_msats_per_1k": mscw_1k,
         },
     )
-    return mspp_1k, mspc_1k, mscr_1k, mscw_1k
+    return PricingRates(
+        input_1k=mspp_1k,
+        output_1k=mspc_1k,
+        cache_read_1k=mscr_1k,
+        cache_write_1k=mscw_1k,
+    )
 
 
 def _resolve_provider_fee(model_id: str) -> float:
@@ -486,7 +507,7 @@ def _calculate_from_usd_cost(
     output_tokens: int,
     response_data: dict,
     provider_fee: float | None,
-    pricing_rates: tuple[float, float, float, float] | None = None,
+    pricing_rates: PricingRates | None = None,
 ) -> CostData:
     """Calculate cost from USD figures, deriving input/output split from tokens."""
     if provider_fee is None:
@@ -533,7 +554,9 @@ def _calculate_from_usd_cost(
     cache_read_msats = 0
     cache_creation_msats = 0
     if pricing_rates is not None:
-        input_rate, _, cache_read_rate, cache_creation_rate = pricing_rates
+        input_rate = pricing_rates.input_1k
+        cache_read_rate = pricing_rates.cache_read_1k
+        cache_creation_rate = pricing_rates.cache_write_1k
         regular_weight = input_tokens * input_rate
         cache_read_weight = cache_read_tokens * cache_read_rate
         cache_creation_weight = cache_creation_tokens * cache_creation_rate

--- a/routstr/payment/cost_calculation.py
+++ b/routstr/payment/cost_calculation.py
@@ -54,12 +54,19 @@ class PricingRates(NamedTuple):
     The four arrived as a bare tuple, unpacked positionally at two call sites.
     Two of them are cache rates that routinely fall back to the prompt rate,
     which makes a transposition read as a plausible bill rather than a crash.
+
+    ``cache_read_inferred`` and ``cache_write_inferred`` are ``True`` when the
+    cache rate fell back to the full prompt rate because neither the catalogue
+    nor the operator supplied one. That distinguishes a rate the node was told
+    from one it invented, which the rate alone cannot: both arrive as a float.
     """
 
     input_1k: float
     output_1k: float
     cache_read_1k: float
     cache_write_1k: float
+    cache_read_inferred: bool
+    cache_write_inferred: bool
 
 
 def _empty_cost(cls: type[CostData] = CostData) -> CostData:
@@ -222,6 +229,8 @@ async def calculate_cost(
                         output_1k=float(settings.fixed_per_1k_output_tokens) * 1000.0,
                         cache_read_1k=fixed_input_rate,
                         cache_write_1k=fixed_input_rate,
+                        cache_read_inferred=False,
+                        cache_write_inferred=False,
                     )
             return _calculate_from_usd_cost(
                 usd_cost,
@@ -419,6 +428,8 @@ def _get_pricing_rates(
             mspc_1k = mspc * 1_000_000.0
             mscr_1k = mscr * 1_000_000.0 if mscr > 0 else mspp_1k
             mscw_1k = mscw * 1_000_000.0 if mscw > 0 else mspp_1k
+            cache_read_inferred = mscr <= 0
+            cache_write_inferred = mscw <= 0
             source = "configured"
         except Exception as e:
             logger.error("Invalid pricing data", extra={"error": str(e)})
@@ -460,6 +471,8 @@ def _get_pricing_rates(
             if cache_write_usd > 0
             else mspp_1k
         )
+        cache_read_inferred = cache_read_usd <= 0
+        cache_write_inferred = cache_write_usd <= 0
         source = "litellm"
 
     logger.info(
@@ -471,6 +484,11 @@ def _get_pricing_rates(
             "output_price_msats_per_1k": mspc_1k,
             "cache_read_price_msats_per_1k": mscr_1k,
             "cache_write_price_msats_per_1k": mscw_1k,
+            # `pricing_source` covers the prompt and completion rates only. A
+            # cache rate the catalogue never supplied is the full prompt rate
+            # wearing the same label, so it gets its own source.
+            "cache_read_source": "inferred" if cache_read_inferred else source,
+            "cache_write_source": "inferred" if cache_write_inferred else source,
         },
     )
     return PricingRates(
@@ -478,6 +496,8 @@ def _get_pricing_rates(
         output_1k=mspc_1k,
         cache_read_1k=mscr_1k,
         cache_write_1k=mscw_1k,
+        cache_read_inferred=cache_read_inferred,
+        cache_write_inferred=cache_write_inferred,
     )
 
 

--- a/tests/unit/test_cache_rate_provenance.py
+++ b/tests/unit/test_cache_rate_provenance.py
@@ -1,0 +1,308 @@
+"""Cover the record of where each cache rate came from.
+
+When no cache rate is configured for a model, ``_get_pricing_rates`` falls back
+to the full prompt rate for both cache reads and writes.  The rate that results
+is indistinguishable from a real one — both arrive as a float — so the fallback
+is invisible to anything downstream, including the settlement log, which
+reported ``pricing_source`` for the prompt and completion rates and said
+nothing about the cache ones.
+
+These tests pin that the existing "Applied model-specific pricing" record now
+carries a source for each cache rate, that ``inferred`` appears only when
+neither the catalogue nor the operator supplied one, that the catalogue's own
+label is used when it did, and that none of this changes what a caller is
+charged.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from routstr.core.settings import settings
+from routstr.payment.cost_calculation import CostData, calculate_cost
+from routstr.payment.models import Architecture, Model, Pricing
+
+
+def _model(
+    *,
+    fwd_id: str = "test-model",
+    prompt: float = 1.0e-7,
+    completion: float = 2.0e-7,
+    cache_read: float = 0.0,
+    cache_write: float = 0.0,
+) -> Model:
+    """Build a minimal ``Model`` with usable sats_pricing."""
+    return Model(
+        id=fwd_id,
+        name=fwd_id,
+        created=0,
+        description="",
+        context_length=128_000,
+        architecture=Architecture(
+            modality="text",
+            input_modalities=["text"],
+            output_modalities=["text"],
+            tokenizer="unknown",
+            instruct_type=None,
+        ),
+        pricing=Pricing(
+            prompt=prompt,
+            completion=completion,
+            input_cache_read=cache_read,
+            input_cache_write=cache_write,
+        ),
+        sats_pricing=Pricing(
+            prompt=prompt / 5.0e-5,
+            completion=completion / 5.0e-5,
+            input_cache_read=cache_read / 5.0e-5 if cache_read else 0.0,
+            input_cache_write=cache_write / 5.0e-5 if cache_write else 0.0,
+        ),
+        enabled=True,
+    )
+
+
+def _usage_response(model_id: str) -> dict[str, Any]:
+    """A response carrying both cache-read and cache-write tokens."""
+    return {
+        "model": model_id,
+        "usage": {
+            "prompt_tokens": 200,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {"cached_tokens": 100},
+            "cache_creation_input_tokens": 30,
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _pin_sats() -> Iterator[None]:
+    with patch("routstr.payment.cost_calculation.sats_usd_price", return_value=5.0e-5):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _attach_caplog(caplog: pytest.LogCaptureFixture) -> Iterator[None]:
+    """Attach caplog handler to the cost_calculation logger.
+
+    Routstr loggers use ``propagate=False`` after ``setup_logging`` runs,
+    so the root-level handler caplog attaches cannot see their records.
+    """
+    cost_logger = logging.getLogger("routstr.payment.cost_calculation")
+    cost_logger.addHandler(caplog.handler)
+    yield
+    cost_logger.removeHandler(caplog.handler)
+
+
+def _pricing_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r for r in caplog.records if r.getMessage() == "Applied model-specific pricing"
+    ]
+
+
+def _only_pricing_record(caplog: pytest.LogCaptureFixture) -> logging.LogRecord:
+    records = _pricing_records(caplog)
+    assert len(records) == 1, (
+        f"expected one pricing record per settlement, got {len(records)}"
+    )
+    return records[0]
+
+
+# -- the source of each cache rate ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_cache_rates_are_recorded_as_inferred(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Neither rate configured → both are the prompt rate under another name."""
+    model = _model(cache_read=0.0, cache_write=0.0)
+
+    with caplog.at_level(logging.INFO):
+        await calculate_cost(
+            _usage_response(model.id), max_cost=100_000, model_obj=model
+        )
+
+    record = _only_pricing_record(caplog)
+    assert record.cache_read_source == "inferred"  # type: ignore[attr-defined]
+    assert record.cache_write_source == "inferred"  # type: ignore[attr-defined]
+
+    # The claim the label makes: the rate really is the prompt rate.
+    assert record.cache_read_price_msats_per_1k == pytest.approx(  # type: ignore[attr-defined]
+        record.input_price_msats_per_1k  # type: ignore[attr-defined]
+    )
+    assert record.cache_write_price_msats_per_1k == pytest.approx(  # type: ignore[attr-defined]
+        record.input_price_msats_per_1k  # type: ignore[attr-defined]
+    )
+
+
+@pytest.mark.asyncio
+async def test_configured_cache_rates_keep_the_catalogue_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rate the node was given is labelled like the rates beside it."""
+    model = _model(cache_read=1.0e-8, cache_write=1.25e-7)
+
+    with caplog.at_level(logging.INFO):
+        await calculate_cost(
+            _usage_response(model.id), max_cost=100_000, model_obj=model
+        )
+
+    record = _only_pricing_record(caplog)
+    assert record.pricing_source == "configured"  # type: ignore[attr-defined]
+    assert record.cache_read_source == "configured"  # type: ignore[attr-defined]
+    assert record.cache_write_source == "configured"  # type: ignore[attr-defined]
+    assert record.cache_read_price_msats_per_1k != pytest.approx(  # type: ignore[attr-defined]
+        record.input_price_msats_per_1k  # type: ignore[attr-defined]
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_two_cache_rates_are_reported_independently(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One configured rate must not vouch for the other.
+
+    Cache reads and writes are supplied separately and go missing separately —
+    a catalogue that knows the read rate routinely omits the write one.
+    """
+    model = _model(cache_read=1.0e-8, cache_write=0.0)
+
+    with caplog.at_level(logging.INFO):
+        await calculate_cost(
+            _usage_response(model.id), max_cost=100_000, model_obj=model
+        )
+
+    record = _only_pricing_record(caplog)
+    assert record.cache_read_source == "configured"  # type: ignore[attr-defined]
+    assert record.cache_write_source == "inferred"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_source_is_recorded_even_with_no_cache_tokens(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The label describes the rate, not the request that happened to use it.
+
+    An operator asking "is this model priced correctly?" needs the answer
+    before the traffic that would expose it, not after.
+    """
+    model = _model(cache_read=0.0, cache_write=0.0)
+
+    with caplog.at_level(logging.INFO):
+        await calculate_cost(
+            {
+                "model": model.id,
+                "usage": {"prompt_tokens": 200, "completion_tokens": 50},
+            },
+            max_cost=100_000,
+            model_obj=model,
+        )
+
+    record = _only_pricing_record(caplog)
+    assert record.cache_read_source == "inferred"  # type: ignore[attr-defined]
+    assert record.cache_write_source == "inferred"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_litellm_priced_model_reports_the_litellm_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A model with no catalogue pricing is rated from litellm, and says so."""
+    model = _model(fwd_id="litellm-only")
+    model.sats_pricing = None
+
+    litellm_entry = {
+        "input_cost_per_token": 1.0e-7,
+        "output_cost_per_token": 2.0e-7,
+        "cache_read_input_token_cost": 1.0e-8,
+    }
+    with (
+        patch("routstr.payment.models.litellm_cost_entry", return_value=litellm_entry),
+        caplog.at_level(logging.INFO),
+    ):
+        await calculate_cost(
+            _usage_response(model.id),
+            max_cost=100_000,
+            model_obj=model,
+            provider_fee=1.0,
+        )
+
+    record = _only_pricing_record(caplog)
+    assert record.pricing_source == "litellm"  # type: ignore[attr-defined]
+    assert record.cache_read_source == "litellm"  # type: ignore[attr-defined]
+    # litellm's entry has no cache-write rate, so that one is still invented.
+    assert record.cache_write_source == "inferred"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_fixed_pricing_records_no_rate_provenance(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``fixed_pricing`` is a flat rate with no cache concept to be missing.
+
+    It short-circuits before any rate is resolved, so there is no pricing
+    record at all — nothing was sourced, and nothing is claimed.
+    """
+    monkeypatch.setattr(settings, "fixed_pricing", True)
+    monkeypatch.setattr(settings, "fixed_per_1k_input_tokens", 0.001)
+    monkeypatch.setattr(settings, "fixed_per_1k_output_tokens", 0.001)
+
+    model = _model(cache_read=0.0, cache_write=0.0)
+
+    with caplog.at_level(logging.INFO):
+        await calculate_cost(
+            _usage_response(model.id), max_cost=100_000, model_obj=model
+        )
+
+    assert _pricing_records(caplog) == []
+
+
+# -- billing-invariance --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_charged_amount_unchanged() -> None:
+    """Recording where a rate came from must not change what it charges.
+
+    Pin the exact cost the pre-change code produces for a request with cached
+    tokens and no configured cache rates.
+    """
+    model = _model(cache_read=0.0, cache_write=0.0)
+
+    cost = await calculate_cost(
+        _usage_response(model.id), max_cost=100_000, model_obj=model
+    )
+    assert isinstance(cost, CostData)
+
+    # prompt rate: 1e-7 / 5e-5 = 0.002 sats/token -> 2000 msats/1k
+    # completion rate: 2e-7 / 5e-5 = 0.004 sats/token -> 4000 msats/1k
+    #
+    # `input_msats` is the whole input side, cache included; the two cache
+    # msats fields are components of it, not additions to it:
+    #   non-cached  70 tokens x 2000/1000 =  140 msats
+    #   cache read 100 tokens x 2000/1000 =  200 msats
+    #   cache write 30 tokens x 2000/1000 =   60 msats
+    #                                       --------
+    #   input                                400 msats
+    #   output      50 tokens x 4000/1000 =  200 msats
+    #                                       --------
+    #   total                                600 msats
+    assert cost.total_msats == 600
+    assert cost.input_msats == 400
+    assert cost.output_msats == 200
+    assert cost.cache_read_msats == 200
+    assert cost.cache_creation_msats == 60
+    assert cost.base_msats == 0
+
+    # The token fields do not mirror the msats fields: `input_tokens` is the
+    # non-cached remainder (200 - 100 - 30), where `input_msats` is the total.
+    assert cost.input_tokens == 70
+    assert cost.output_tokens == 50
+    assert cost.cache_read_input_tokens == 100
+    assert cost.cache_creation_input_tokens == 30


### PR DESCRIPTION
## Why

When a model has no `input_cache_read` or `input_cache_write`, billing falls back
to the full prompt rate for those tokens. The rate that results is
indistinguishable from a real one — both arrive as a float — so nothing
downstream can tell a rate the node was given from one it invented.

The settlement path already logs `Applied model-specific pricing` with a
`pricing_source` field on every request. That label covers the prompt and
completion rates only, so it reads `configured` on a request whose cache tokens
were priced by the fallback. This PR makes that record say what it knows.

**The fallback itself is unchanged and no charged amount moves.** That is
deliberate: there is no better number to fall back to.

- No upstream API publishes cache pricing. `/v1/models` has no caching field
  anywhere in the OpenAI-compatible shape, and Anthropic's `count_tokens` never
  consults the cache. Cache rates live in human-facing pricing pages.
- Both catalogue sources are already consulted before a rate can be called
  inferred — the provider feed, then litellm via `backfill_cache_pricing`.
  litellm carries a cache-read rate for 873 of 2580 chat models; for the rest
  there is no source left to try, and those are disproportionately the custom
  and self-hosted upstreams a node operator configures by hand.
- The only way to observe a real cache rate is to cause a cache hit and read the
  cost back — which requires the upstream to report a USD cost for the request.
  When it does, that reported figure is what we bill and the cache rate only
  moves the breakdown, not the total. So the measurement is available exactly
  where the rate does not matter, and unavailable exactly where it does.

That leaves one real fix, and it already ships: the operator sets the rate.
`input_cache_read` is in `BILLABLE_PRICING_FIELDS` and accepted by the admin
model PATCH. What was missing is any signal that it needs setting.

## What

Two commits.

1. `_get_pricing_rates` returned four bare floats, unpacked positionally at two
   call sites. Two of the four are cache rates that routinely fall back to the
   prompt rate, so a transposed pair does not crash — it bills a
   plausible-looking wrong amount. It now returns a `PricingRates` named tuple.
   No behaviour change.
2. `PricingRates` carries `cache_read_inferred` / `cache_write_inferred`, and
   the existing pricing record gains `cache_read_source` and
   `cache_write_source` — each `configured`, `litellm` or `inferred`.

No new log lines and no new severity: one record that already fired on every
settlement gains two fields. The two rates are tracked separately, because a
catalogue that knows the read rate routinely omits the write one.

`fixed_pricing` short-circuits before any rate is resolved, so it emits no
pricing record at all — nothing is sourced and nothing is claimed.

## Tested

Seven unit tests, through `calculate_cost`: both rates missing, both configured,
one of each, no cache tokens in the request, the litellm branch labelling its own
rates, the `fixed_pricing` exemption, and billing invariance pinning the exact
msats breakdown rather than that it is positive.

Each was checked against a sabotaged implementation: dropping the two fields
fails five of them, labelling everything with the catalogue source fails four,
and letting the read flag stand in for the write flag fails the independence
test specifically.

Both commits are independently green — lint, type-check and the 1301/1308 unit
tests pass at each — so the branch stays bisectable when merged unsquashed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhvy9xFm54E2i5yMevUpHG
