### PR TITLE
fix(auth): clamp overrun charge to a delegated child's balance limit

### DIFF
--- a/routstr/auth.py
+++ b/routstr/auth.py
@@ -1255,6 +1255,7 @@ async def _charge_reservation_rows(
     reserved_msats: int,
     charge_msats: int,
     extra_billing_guards: tuple = (),
+    extra_child_guards: tuple = (),
 ) -> bool:
     """Release the reserved amount and record the charge on the billing row
     (and the child row when different) inside the caller's transaction.
@@ -1289,11 +1290,15 @@ async def _charge_reservation_rows(
         return False
 
     if key_hash != billing_key_hash:
-        child_result = await session.exec(  # type: ignore[call-overload]
+        child_stmt = (
             update(ApiKey)
             .where(col(ApiKey.hashed_key) == key_hash)
             .where(col(ApiKey.reserved_balance) >= reserved_msats)
-            .values(
+        )
+        for guard in extra_child_guards:
+            child_stmt = child_stmt.where(guard)
+        child_result = await session.exec(  # type: ignore[call-overload]
+            child_stmt.values(
                 reserved_balance=col(ApiKey.reserved_balance) - reserved_msats,
                 reserved_at=case(
                     (
@@ -1597,6 +1602,35 @@ async def adjust_payment_for_tokens(
                     sibling_reserved = observed_reserved - deducted_max_cost
                     chargeable_msats = max(0, observed_balance - sibling_reserved)
                     actual_charge_msats = min(chargeable_msats, total_cost_msats)
+                    # A delegated child's balance_limit is enforced at reservation
+                    # time, so an overrun charge must not push its total_spent past
+                    # the limit. Re-read the child so the clamp uses its current
+                    # total_spent; the SQL guard plus the retry loop provide the
+                    # correctness, not a row lock (with_for_update is a no-op on
+                    # SQLite).
+                    child_guard = None
+                    if key.hashed_key != billing_key.hashed_key:
+                        locked_child_key = (
+                            await session.exec(
+                                select(ApiKey)
+                                .where(col(ApiKey.hashed_key) == key.hashed_key)
+                                .with_for_update()
+                                .execution_options(populate_existing=True)
+                            )
+                        ).one()
+                        if locked_child_key.balance_limit is not None:
+                            child_remaining = max(
+                                0,
+                                locked_child_key.balance_limit
+                                - locked_child_key.total_spent,
+                            )
+                            actual_charge_msats = min(
+                                actual_charge_msats, child_remaining
+                            )
+                            child_guard = (
+                                col(ApiKey.total_spent) + actual_charge_msats
+                                <= col(ApiKey.balance_limit)
+                            )
                     if await _charge_reservation_rows(
                         session,
                         billing_key_hash=billing_key.hashed_key,
@@ -1606,6 +1640,9 @@ async def adjust_payment_for_tokens(
                         extra_billing_guards=(
                             col(ApiKey.balance) == observed_balance,
                             col(ApiKey.reserved_balance) == observed_reserved,
+                        ),
+                        extra_child_guards=(
+                            (child_guard,) if child_guard is not None else ()
                         ),
                     ):
                         break

--- a/tests/unit/test_delegated_key_balance_limit.py
+++ b/tests/unit/test_delegated_key_balance_limit.py
@@ -1,0 +1,260 @@
+"""Delegated-child settlement must never exceed the child's balance limit.
+
+A delegated key (one whose ``parent_key_hash`` points at another key) draws its
+``balance`` from the parent but owns its own ``balance_limit`` and ``total_spent``.
+The limit is enforced at reservation time, but settlement applies the final charge
+(which can overrun the reservation when real usage exceeds the discounted
+estimate) without re-checking the limit. These tests pin the exact post-settlement
+state of a delegated child: an overrun must be clamped to the remaining limit,
+and the parent and child must record the same clamped charge.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from routstr.auth import (
+    adjust_payment_for_tokens,
+    get_reservation_snapshot,
+    pay_for_request,
+)
+from routstr.core.db import ApiKey
+from routstr.payment.cost_calculation import CostData, MaxCostData
+
+
+async def _engine() -> AsyncEngine:
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    return engine
+
+
+def _cost(total_msats: int) -> CostData:
+    return CostData(
+        base_msats=0,
+        input_msats=total_msats,
+        output_msats=0,
+        total_msats=total_msats,
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_overrun_is_clamped_to_the_childs_remaining_limit() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+        parent_before = parent.balance
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(120_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(parent)
+        await session.refresh(child)
+        assert child.balance_limit is not None
+        assert child.total_spent == child.balance_limit
+        assert child.reserved_balance == 0
+        assert parent_before - parent.balance == child.total_spent
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_parent_and_child_record_the_same_clamped_charge() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+        parent_before = parent.balance
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(120_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(parent)
+        await session.refresh(child)
+        assert parent_before - parent.balance == child.total_spent
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_child_without_a_limit_is_charged_the_full_overrun() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(hashed_key="child", parent_key_hash="parent", balance=0)
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(120_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(child)
+        assert child.total_spent == 120_000
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_normal_settlement_within_the_limit_is_unchanged() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(10_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(child)
+        assert child.total_spent == 10_000
+        assert child.reserved_balance == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_underrun_refunds_the_child_without_breaking_the_limit() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(5_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(child)
+        assert child.total_spent == 5_000
+        assert child.reserved_balance == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_max_cost_settlement_without_pricing_charges_the_child_nothing() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(
+                return_value=MaxCostData(
+                    base_msats=0, input_msats=0, output_msats=0, total_msats=0
+                )
+            ),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(child)
+        assert child.total_spent == 0
+        assert child.reserved_balance == 0
+
+    await engine.dispose()

--- a/tests/unit/test_delegated_key_balance_limit.py
+++ b/tests/unit/test_delegated_key_balance_limit.py
@@ -258,3 +258,49 @@ async def test_a_max_cost_settlement_without_pricing_charges_the_child_nothing()
         assert child.reserved_balance == 0
 
     await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_a_midflight_limit_drop_does_not_free_the_settlement() -> None:
+    engine = await _engine()
+    parent = ApiKey(hashed_key="parent", balance=1_000_000)
+    child = ApiKey(
+        hashed_key="child",
+        parent_key_hash="parent",
+        balance=0,
+        balance_limit=100_000,
+        total_spent=80_000,
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add_all([parent, child])
+        await session.commit()
+        parent_before = parent.balance
+
+        await pay_for_request(child, 10_000, session)
+        snapshot = await get_reservation_snapshot(child, session)
+
+        # An admin lowers the limit below total_spent + the incoming charge while
+        # the reservation is still in flight.
+        child.balance_limit = 83_000
+        session.add(child)
+        await session.commit()
+
+        with patch(
+            "routstr.auth.calculate_cost",
+            AsyncMock(return_value=_cost(4_000)),
+        ):
+            await adjust_payment_for_tokens(
+                child,
+                {"model": "test", "usage": {}},
+                session,
+                10_000,
+                reservation_snapshot=snapshot,
+            )
+
+        await session.refresh(parent)
+        await session.refresh(child)
+        assert parent_before - parent.balance == 4_000
+        assert child.total_spent == 84_000
+        assert child.reserved_balance == 0
+
+    await engine.dispose()
+


### PR DESCRIPTION
## The bug

A delegated child key's `balance_limit` is enforced when a request **reserves** funds, but not when it **settles**. If the response costs more than was reserved, the overrun path charges whatever the parent's balance allows and never re-checks the child's limit — so a child key can spend past its limit by overrunning, repeatedly.

## The fix

In the overrun branch of `adjust_payment_for_tokens`, re-read the child row and clamp the charge to its remaining limit (`balance_limit - total_spent`). The same condition is passed down as a SQL guard on the child `UPDATE`, so a concurrent writer cannot slip in between the read and the write; a failed guard falls into the existing retry loop.

## Concessions

- **The node absorbs the overrun above the limit.** The clamp reduces the charge on the parent row too, so the excess is not billed to anyone. This matches the balance clamp directly above it, which already caps at what the parent can pay.
- **The guard is opt-in, not unconditional.** Putting it inside `_charge_reservation_rows` for every caller is simpler but wrong: if an admin lowers a child's limit while a request is in flight, an ordinary in-authorization settlement would silently fail the guard, exhaust the retry loop, and release the reservation without charging anything. `test_a_midflight_limit_drop_does_not_free_the_settlement` pins that case.
- `with_for_update()` is a no-op on SQLite. Correctness comes from the SQL guard plus the retry loop, not from row locking — the comment says so rather than implying a lock that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
