### PR TITLE
fix(wallet): credit the unused LNURL melt fee reserve back to the key

### DIFF
--- a/routstr/balance.py
+++ b/routstr/balance.py
@@ -531,13 +531,30 @@ async def refund_wallet_endpoint(
     try:
         refund_currency = key.refund_currency or "sat"
         if key.refund_address:
-            await send_to_lnurl(
+            net_spent = await send_to_lnurl(
                 remaining_balance,
                 key.refund_currency or "sat",
                 effective_refund_mint,
                 key.refund_address,
             )
             result = {"recipient": key.refund_address}
+            # The payout spends only the invoice amount while the debit
+            # zeroed the full balance; credit the unused melt fee reserve
+            # back as a separate write once the melt has confirmed.
+            unused = remaining_balance - net_spent
+            if unused > 0:
+                credit_msat = (
+                    unused * 1000
+                    if (key.refund_currency or "sat") == "sat"
+                    else unused
+                )
+                credit_stmt = (
+                    update(ApiKey)
+                    .where(col(ApiKey.hashed_key) == key.hashed_key)
+                    .values(balance=col(ApiKey.balance) + credit_msat)
+                )
+                await session.exec(credit_stmt)  # type: ignore[call-overload]
+                await session.commit()
         else:
             token = await send_token(
                 remaining_balance, refund_currency, effective_refund_mint

--- a/routstr/payment/lnurl.py
+++ b/routstr/payment/lnurl.py
@@ -270,11 +270,16 @@ async def raw_send_to_lnurl(
 
     Args:
         wallet: Wallet instance
+        proofs: Unreserved proofs available to fund the melt
         lnurl: LNURL string (can be lightning:, user@host, bech32, or direct URL)
+        unit: Currency unit of the proofs ("sat" or "msat")
         amount: Amount to send in the specified currency unit
+        on_melt_quote: Optional callback invoked with the melt quote id before dispatch
 
     Returns:
-        Amount actually paid in the specified currency unit
+        The net amount the wallet spent — the selected proofs minus the melt
+        change, in the wallet's unit — not the invoice amount paid to the
+        recipient.
 
     Raises:
         WalletError: If amount is outside LNURL limits or insufficient balance
@@ -396,7 +401,14 @@ async def raw_send_to_lnurl(
 
     melt_state = getattr(melt_response, "state", None)
     if melt_state == MeltQuoteState.paid:
-        return final_amount
+        # The melt's change is the unused fee reserve (plus any over-
+        # provision), so the wallet's net debit is the selected proofs
+        # minus the change - the amount actually spent, not the shrunk
+        # invoice amount.
+        change = getattr(melt_response, "change", None) or []
+        return sum(int(p.amount) for p in proofs) - sum(
+            int(c.amount) for c in change
+        )
     if melt_state == MeltQuoteState.unpaid:
         await wallet.set_reserved_for_send(proofs, reserved=False)
         raise LNURLError("Cashu mint confirmed that the melt was unpaid")
@@ -417,7 +429,9 @@ async def raw_send_to_lnurl(
         ) from reconciliation_error
 
     if quote is not None and quote.state == MeltQuoteState.paid:
-        return final_amount
+        # No melt response survived to read change from, so the conservative
+        # net spend is the full selection; no unused reserve is credited.
+        return sum(int(p.amount) for p in proofs)
     if quote is not None and quote.state == MeltQuoteState.unpaid:
         # A just-dispatched quote can briefly report unpaid before transitioning.
         try:

--- a/routstr/wallet.py
+++ b/routstr/wallet.py
@@ -2298,7 +2298,7 @@ async def _payout_mint_and_unit(mint_url: str, unit: str) -> None:
             else _sats_to_msats(settings.min_payout_sat)
         )
         if available_balance > min_amount:
-            amount_received = await raw_send_to_lnurl(
+            net_spent = await raw_send_to_lnurl(
                 wallet,
                 proofs,
                 settings.receive_ln_address,
@@ -2311,7 +2311,7 @@ async def _payout_mint_and_unit(mint_url: str, unit: str) -> None:
                     "mint_url": mint_url,
                     "unit": unit,
                     "balance": available_balance,
-                    "amount_received": amount_received,
+                    "net_spent": net_spent,
                 },
             )
     except Exception as e:
@@ -2635,7 +2635,7 @@ async def periodic_routstr_fee_payout() -> None:
                     attempt_quote_id = quote_id
 
                 try:
-                    amount_received = await raw_send_to_lnurl(
+                    net_spent = await raw_send_to_lnurl(
                         wallet,
                         proofs,
                         ROUTSTR_LN_ADDRESS,
@@ -2693,7 +2693,7 @@ async def periodic_routstr_fee_payout() -> None:
                     "Routstr fee payout sent",
                     extra={
                         "accumulated_sats": accumulated_sats,
-                        "amount_received": amount_received,
+                        "net_spent": net_spent,
                     },
                 )
         except Exception as e:

--- a/tests/unit/test_lnurl_amount_and_destination.py
+++ b/tests/unit/test_lnurl_amount_and_destination.py
@@ -133,7 +133,7 @@ async def test_raw_send_to_lnurl_accepts_exact_invoice() -> None:
             wallet, proofs, "owner@ln.tld", "sat", amount=1000
         )
 
-    assert paid == EXPECTED_QUOTE_SAT * 1000
+    assert paid == 1000  # 1000 sat selected, no change returned
     wallet.select_to_send.assert_not_awaited()
     wallet.set_reserved_for_send.assert_awaited_once_with(proofs, reserved=True)
     wallet.melt.assert_awaited_once()
@@ -156,7 +156,7 @@ async def test_raw_send_to_lnurl_msat_unit_compares_in_wallet_unit() -> None:
             wallet, proofs, "owner@ln.tld", "msat", amount=1_000_000
         )
 
-    assert paid == 999_999
+    assert paid == 1_000_000  # 1_000_000 msat selected, no change
 
 
 @pytest.mark.asyncio
@@ -189,7 +189,7 @@ async def test_raw_send_to_lnurl_requotes_for_exact_input_fees_without_recursion
             on_melt_quote=checkpoint,
         )
 
-    assert paid == 1_475_000
+    assert paid == 1500  # 1500 sat selected, no change returned
     assert wallet.melt_quote.await_count == 2
     checkpoint.assert_awaited_once_with("q2")
     wallet.select_to_send.assert_not_called()

--- a/tests/unit/test_lnurl_change_reconciliation.py
+++ b/tests/unit/test_lnurl_change_reconciliation.py
@@ -1,0 +1,170 @@
+"""LNURL payouts must credit the unused melt fee reserve back to the key.
+
+The refund-to-LNURL path in ``balance.py`` zeroes the key's balance before
+dispatching the payout, then calls ``send_to_lnurl`` and discards the return
+value. But the payout spends only the invoice amount while the ``fee_reserve``
+reserved the proofs for a larger fee; the difference returns as melt ``change``
+and is currently retained in the node's wallet. These tests pin the two seams:
+``raw_send_to_lnurl`` must return the net amount actually spent, and
+``balance.py`` must credit the unused reserve back to the key in the correct
+unit (including the sat-to-msat conversion).
+"""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cashu.core.base import MeltQuoteState
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from routstr.balance import refund_wallet_endpoint
+from routstr.core.db import ApiKey
+from routstr.mint import MintRateGuard
+from routstr.payment.lnurl import raw_send_to_lnurl
+
+
+@pytest.fixture(autouse=True)
+def _clear_mint_guards() -> Iterator[None]:
+    MintRateGuard._guards.clear()
+    yield
+    MintRateGuard._guards.clear()
+
+
+async def _engine() -> AsyncEngine:
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    return engine
+
+
+LNURL_DATA = {
+    "callback_url": "https://ln.tld/cb",
+    "min_sendable": 1_000,
+    "max_sendable": 100_000_000,
+}
+
+
+@pytest.mark.asyncio
+async def test_raw_send_to_lnurl_returns_the_net_amount_spent() -> None:
+    """The melt's change is the unused reserve; the returned value must be the
+    net proofs consumed (selected minus change), not the shrunk invoice amount."""
+    proofs = [MagicMock(amount=1_000_000, reserved=False)]
+    wallet = MagicMock(url="https://mint.test")
+    wallet.melt_quote = AsyncMock(
+        side_effect=[
+            MagicMock(fee_reserve=10_000, quote="q1", amount=1_000_000),
+            MagicMock(fee_reserve=10_000, quote="q2", amount=990_000),
+        ]
+    )
+    wallet.melt = AsyncMock(
+        return_value=MagicMock(state=MeltQuoteState.paid, change=[MagicMock(amount=3_000)])
+    )
+    wallet.get_fees_for_proofs = MagicMock(return_value=0)
+    wallet.set_reserved_for_send = AsyncMock()
+    wallet.set_reserved_for_melt = AsyncMock()
+
+    with (
+        patch("routstr.payment.lnurl.get_lnurl_data", AsyncMock(return_value=LNURL_DATA)),
+        patch(
+            "routstr.payment.lnurl.get_lnurl_invoice",
+            AsyncMock(return_value=("lnbc1...", {})),
+        ),
+    ):
+        paid = await raw_send_to_lnurl(
+            wallet, proofs, "owner@ln.tld", "msat", amount=1_000_000
+        )
+
+    # selected 1_000_000 msat, change 3_000 msat -> net spent 997_000 msat.
+    assert paid == 997_000
+
+
+@pytest.mark.asyncio
+async def test_an_lnurl_payout_returns_the_unused_reserve_to_the_balance() -> None:
+    engine = await _engine()
+    key = ApiKey(
+        hashed_key="refund-key",
+        balance=1_000_000,
+        refund_address="owner@ln.tld",
+        refund_currency="msat",
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add(key)
+        await session.commit()
+
+        with patch(
+            "routstr.balance.send_to_lnurl", AsyncMock(return_value=997_000)
+        ):
+            await refund_wallet_endpoint(
+                authorization="Bearer sk-refund-key",
+                x_cashu=None,
+                session=session,
+            )
+
+        await session.refresh(key)
+        assert key.balance == 3_000
+        assert key.reserved_balance == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_sat_payout_converts_the_reserve_back_to_msats() -> None:
+    engine = await _engine()
+    key = ApiKey(
+        hashed_key="refund-key",
+        balance=1_000_000,
+        refund_address="owner@ln.tld",
+        refund_currency="sat",
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add(key)
+        await session.commit()
+
+        # send_to_lnurl is fed 1000 sats and spends 997 sats net.
+        with patch("routstr.balance.send_to_lnurl", AsyncMock(return_value=997)):
+            await refund_wallet_endpoint(
+                authorization="Bearer sk-refund-key",
+                x_cashu=None,
+                session=session,
+            )
+
+        await session.refresh(key)
+        # 3 unused sats, credited back in msats.
+        assert key.balance == 3_000
+        assert key.reserved_balance == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_lnurl_payout_still_restores_the_full_balance() -> None:
+    engine = await _engine()
+    key = ApiKey(
+        hashed_key="refund-key",
+        balance=1_000,
+        refund_address="owner@ln.tld",
+        refund_currency="msat",
+    )
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        session.add(key)
+        await session.commit()
+
+        with patch(
+            "routstr.balance.send_to_lnurl",
+            AsyncMock(side_effect=RuntimeError("mint unavailable")),
+        ):
+            with pytest.raises(HTTPException):
+                await refund_wallet_endpoint(
+                    authorization="Bearer sk-refund-key",
+                    x_cashu=None,
+                    session=session,
+                )
+
+        await session.refresh(key)
+        assert key.balance == 1_000
+        assert key.reserved_balance == 0
+
+    await engine.dispose()


### PR DESCRIPTION
## The bug

A Lightning payout debits the key's full balance, then melts proofs to pay the invoice. The melt carries a fee reserve, and the mint returns the unused part of it as change. That change was never credited back to the key — the key was debited the whole reserve whether or not the routing fee needed it. Every payout to a refund address silently overcharged by the unused reserve.

## The fix

`raw_send_to_lnurl` now returns the net amount the wallet actually spent — the selected proofs minus the melt change — instead of the invoice amount. The refund endpoint credits `remaining_balance - net_spent` back to the key in a separate write, once the melt has confirmed.

## Concessions

- **The return-value contract changed deliberately.** The function used to report the amount paid to the recipient; it now reports what the wallet spent. Three assertions in `test_lnurl_amount_and_destination.py` were updated to match, the docstring states the new meaning explicitly, and the call sites in `wallet.py` were renamed.
- **The crash window is narrowed, not closed.** A crash between the melt confirming and the credit-back landing still loses the reserve. Strictly better than today, where it was lost every time.
- **The reconciliation path stays conservative.** When no melt response survives to read change from, the full selection is reported as spent and nothing is credited — under-crediting rather than inventing a refund from an unknown state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

