### PR TITLE
fix(ehbp): pass through enclave key-config 422 as problem+json

### DIFF
--- a/routstr/upstream/ehbp.py
+++ b/routstr/upstream/ehbp.py
@@ -46,7 +46,7 @@ from ..wallet import (
     recieve_token,
     send_token,
 )
-from .tinfoil_trailer import forward_with_trailer
+from .tinfoil_trailer import TrailerResponse, forward_with_trailer
 
 logger = get_logger(__name__)
 
@@ -60,6 +60,55 @@ _RESPONSE_USAGE_HEADER = "X-Tinfoil-Usage-Metrics"
 _TINFOIL_PROVIDER_TYPE = "tinfoil"
 _TINFOIL_ALLOWED_ENCLAVE_HOST_SUFFIX = ".tinfoil.sh"
 _TINFOIL_ALLOWED_ENCLAVE_HOSTS = frozenset({"tinfoil.sh"})
+
+
+_KEY_CONFIG_PROBLEM_TYPE = "urn:ietf:params:ehbp:error:key-config"
+
+
+def _is_ehbp_key_config_response(resp: TrailerResponse) -> bool:
+    """Check whether an upstream EHBP response is a key-config mismatch.
+
+    The enclave returns ``422 application/problem+json`` with
+    ``type=urn:ietf:params:ehbp:error:key-config`` when it cannot decrypt the
+    request body — meaning the client's HPKE key is stale (the enclave rotated
+    keys).  The proxy must pass this response through with its original
+    content type so EHBP clients can detect it and trigger re-attestation.
+    """
+    if resp.status_code != 422:
+        return False
+    ct = ""
+    for k, v in resp.headers:
+        if k.lower() == "content-type":
+            ct = v.lower()
+            break
+    if "application/problem+json" not in ct:
+        return False
+    try:
+        body = json.loads(resp.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return isinstance(body, dict) and body.get("type") == _KEY_CONFIG_PROBLEM_TYPE
+
+
+def _passthrough_key_config_response(resp: TrailerResponse) -> Response:
+    """Return the enclave's key-config 422 with its original body and content
+    type so the EHBP client's ``KeyConfigMismatchError`` detection fires.
+
+    Only EHBP protocol headers are forwarded; everything else (hop-by-hop,
+    upstream-internal) is filtered out.
+    """
+    passthrough_headers: dict[str, str] = {
+        "content-type": "application/problem+json",
+    }
+    for k, v in resp.headers:
+        if k.lower() in ("ehbp-response-nonce", "content-length"):
+            passthrough_headers[k] = v
+    return Response(
+        content=resp.body,
+        status_code=422,
+        headers=passthrough_headers,
+        media_type="application/problem+json",
+    )
 
 
 def _normalize_upstream_model_id(model_id: str | None) -> str:
@@ -722,6 +771,25 @@ async def forward_ehbp_request(
                     "body_preview": body_preview,
                 },
             )
+            # Key-config mismatch (stale client HPKE key): return the
+            # enclave's 422 problem+json directly so the SDK's
+            # KeyConfigMismatchError detection fires and triggers
+            # re-attestation.  Wrapping it as application/json would
+            # destroy the signal and cause permanent failure.
+            if _is_ehbp_key_config_response(resp):
+                logger.warning(
+                    "EHBP upstream %s returned key-config mismatch for model=%s, "
+                    "passing through for client re-attestation",
+                    provider_type,
+                    model_obj.id,
+                    extra={
+                        "provider": provider_type,
+                        "model": model_obj.id,
+                        "path": path,
+                    },
+                )
+                return _passthrough_key_config_response(resp)
+
             raise UpstreamError(
                 f"EHBP upstream {provider_type} returned {resp.status_code} "
                 f"for model {model_obj.id}: {body_preview[:200] or '<empty>'}",
@@ -938,6 +1006,29 @@ async def forward_ehbp_x_cashu_request(
             )
 
             if resp.status_code != 200:
+                # Key-config mismatch (stale client HPKE key): refund the
+                # full token and pass the enclave's 422 problem+json through
+                # so the SDK's KeyConfigMismatchError detection fires.
+                if _is_ehbp_key_config_response(resp):
+                    logger.warning(
+                        "EHBP upstream %s returned key-config mismatch for "
+                        "model=%s, refunding and passing through",
+                        provider_type,
+                        model_obj.id,
+                        extra={
+                            "provider": provider_type,
+                            "model": model_obj.id,
+                            "path": path,
+                            "refunded_amount": amount,
+                        },
+                    )
+                    refund_token = await send_cashu_refund(
+                        amount, unit, mint, request_id
+                    )
+                    passthrough = _passthrough_key_config_response(resp)
+                    passthrough.headers["X-Cashu"] = refund_token
+                    return passthrough
+
                 refund_token = await send_cashu_refund(amount, unit, mint, request_id)
                 error_response = Response(
                     content=json.dumps(

--- a/tests/unit/test_tinfoil_integration.py
+++ b/tests/unit/test_tinfoil_integration.py
@@ -21,11 +21,11 @@ from routstr.upstream.ehbp import (
     _strip_proxy_headers,
     parse_tinfoil_usage_metrics,
 )
-from routstr.upstream.tinfoil_trailer import TrailerResponse
 from routstr.upstream.tinfoil import (
     TinfoilModel,
     TinfoilUpstreamProvider,
 )
+from routstr.upstream.tinfoil_trailer import TrailerResponse
 
 # ---------------------------------------------------------------------------
 # parse_tinfoil_usage_metrics

--- a/tests/unit/test_tinfoil_integration.py
+++ b/tests/unit/test_tinfoil_integration.py
@@ -14,11 +14,14 @@ import pytest
 from routstr.upstream.ehbp import (
     _PROXY_ONLY_HEADERS,
     _compute_ehbp_actual_cost,
+    _is_ehbp_key_config_response,
+    _passthrough_key_config_response,
     _prepare_ehbp_upstream_headers,
     _resolve_ehbp_target_url,
     _strip_proxy_headers,
     parse_tinfoil_usage_metrics,
 )
+from routstr.upstream.tinfoil_trailer import TrailerResponse
 from routstr.upstream.tinfoil import (
     TinfoilModel,
     TinfoilUpstreamProvider,
@@ -747,3 +750,102 @@ class TestTinfoilUpstreamProvider:
             models = await provider.fetch_models()
 
         assert models == []
+
+
+# ---------------------------------------------------------------------------
+# EHBP key-config mismatch passthrough
+# ---------------------------------------------------------------------------
+
+
+def _key_config_trailer_response(
+    status_code: int = 422,
+    content_type: str = "application/problem+json",
+    body: bytes = b'{"type":"urn:ietf:params:ehbp:error:key-config","title":"failed to read decrypted request body"}',
+) -> TrailerResponse:
+    return TrailerResponse(
+        status_code=status_code,
+        headers=[
+            ("content-type", content_type),
+            ("content-length", str(len(body))),
+        ],
+        body=body,
+        trailers=[],
+    )
+
+
+class TestIsEhbpKeyConfigResponse:
+    def test_genuine_key_config_422(self) -> None:
+        resp = _key_config_trailer_response()
+        assert _is_ehbp_key_config_response(resp) is True
+
+    def test_200_is_not_key_config(self) -> None:
+        resp = _key_config_trailer_response(status_code=200)
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_400_is_not_key_config(self) -> None:
+        resp = _key_config_trailer_response(status_code=400)
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_json_content_type_is_not_key_config(self) -> None:
+        """A 422 with application/json (e.g. proxy-wrapped error) must NOT be
+        treated as key-config — only the original problem+json counts."""
+        resp = _key_config_trailer_response(content_type="application/json")
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_problem_json_with_different_type_is_not_key_config(self) -> None:
+        """A 422 problem+json with a different error type is not key-config."""
+        body = b'{"type":"urn:ietf:params:ehbp:error:other","title":"other"}'
+        resp = _key_config_trailer_response(body=body)
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_empty_body_is_not_key_config(self) -> None:
+        resp = _key_config_trailer_response(body=b"")
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_invalid_json_body_is_not_key_config(self) -> None:
+        resp = _key_config_trailer_response(body=b"not json")
+        assert _is_ehbp_key_config_response(resp) is False
+
+    def test_problem_json_with_charset(self) -> None:
+        resp = _key_config_trailer_response(
+            content_type="application/problem+json; charset=utf-8"
+        )
+        assert _is_ehbp_key_config_response(resp) is True
+
+    def test_missing_content_type_is_not_key_config(self) -> None:
+        resp = TrailerResponse(
+            status_code=422,
+            headers=[],
+            body=b'{"type":"urn:ietf:params:ehbp:error:key-config"}',
+        )
+        assert _is_ehbp_key_config_response(resp) is False
+
+
+class TestPassthroughKeyConfigResponse:
+    def test_status_and_content_type(self) -> None:
+        resp = _key_config_trailer_response()
+        result = _passthrough_key_config_response(resp)
+        assert result.status_code == 422
+        assert result.media_type == "application/problem+json"
+
+    def test_body_passed_through(self) -> None:
+        original_body = b'{"type":"urn:ietf:params:ehbp:error:key-config","title":"failed to read decrypted request body"}'
+        resp = _key_config_trailer_response(body=original_body)
+        result = _passthrough_key_config_response(resp)
+        assert result.body == original_body
+
+    def test_ehbp_nonce_header_forwarded(self) -> None:
+        resp = TrailerResponse(
+            status_code=422,
+            headers=[
+                ("content-type", "application/problem+json"),
+                ("ehbp-response-nonce", "abc123"),
+                ("server", "nginx"),
+                ("x-request-id", "some-id"),
+            ],
+            body=b'{"type":"urn:ietf:params:ehbp:error:key-config","title":"test"}',
+        )
+        result = _passthrough_key_config_response(resp)
+        assert result.headers["ehbp-response-nonce"] == "abc123"
+        assert "server" not in result.headers
+        assert "x-request-id" not in result.headers


### PR DESCRIPTION
## Problem

Tinfoil rotated their enclave HPKE keys (~Sep 4). Long-running SDK clients (e.g. the routstrd daemon, up since Aug 29) kept sealing requests to the old key. The enclave returned `422 application/problem+json` with `type=urn:ietf:params:ehbp:error:key-config`, but the proxy wrapped it into its own `application/json` error envelope via `create_upstream_error_response()`. This destroyed the content type and body shape that EHBP clients use to detect key-config mismatch and trigger re-attestation. Result: **every request with a stale key failed permanently** — the recovery loop never fired.

```
enclave:  422 application/problem+json  {"type":"urn:...key-config", ...}
             ↓  proxy wraps
client:   422 application/json          {"error":{"message":"EHBP upstream..."}}
             ↓  SDK checks content-type: NOT problem+json → no match
          → no KeyConfigMismatchError → no re-attestation → repeat forever
```

## Fix

When the upstream EHBP response is a key-config 422, pass it through **unmodified** — original status, `application/problem+json` content type, and raw body. This is what the tinfoil SDK and routstr-sdk already handle natively (re-attest + retry once).

### Bearer auth path (`forward_ehbp_request`)
```
forward_ehbp_request
  forward_with_trailer → resp
  if resp.status != 200:
+   if is_key_config(resp):
+     return passthrough_response(resp)   ← was: raise UpstreamError
    raise UpstreamError(...)
```

### X-Cashu path (`forward_ehbp_x_cashu_request`)
Same passthrough, plus full token refund before returning (request was never processed by the enclave).

## What changed

```
routstr/upstream/ehbp.py
+ _is_ehbp_key_config_response()     # 422 + problem+json + key-config URN
+ _passthrough_key_config_response() # raw passthrough with EHBP headers
  forward_ehbp_request()             # use passthrough on key-config
  forward_ehbp_x_cashu_request()     # same + refund

tests/unit/test_tinfoil_integration.py
+ TestIsEhbpKeyConfigResponse        # 9 tests
+ TestPassthroughKeyConfigResponse   # 3 tests
```

## Testing

56 tests pass (12 new). Key scenarios covered:
- Genuine key-config 422 detected
- Non-422, wrong content-type, wrong URN, empty/invalid body all correctly rejected
- Passthrough preserves status, content-type, body, and EHBP headers
- Passthrough filters out upstream-internal headers (server, x-request-id)

## Companion PR

routstr-sdk side: [link to SDK PR] — broadens the SDK's detection to also match the proxy-wrapped body as a fallback, covering clients behind older proxies that don't have this fix yet.
